### PR TITLE
Baking process speedup

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -472,7 +472,7 @@ class TexToolsSettings(bpy.types.PropertyGroup):
 		description = "Ray distance when baking. When using cage used as extrude distance",
 		default = 0.010,
 		min = 0.000,
-		max = 1000.00
+		max = 1000.00,
 		precision = 3
 	)
 	bake_force_single : bpy.props.BoolProperty(

--- a/__init__.py
+++ b/__init__.py
@@ -470,9 +470,10 @@ class TexToolsSettings(bpy.types.PropertyGroup):
 	bake_ray_distance : bpy.props.FloatProperty(
 		name = "Ray Dist.",
 		description = "Ray distance when baking. When using cage used as extrude distance",
-		default = 0.01,
+		default = 0.010,
 		min = 0.000,
-		max = 100.00
+		max = 1000.00
+		precision = 3
 	)
 	bake_force_single : bpy.props.BoolProperty(
 		name="Single Texture",

--- a/op_bake.py
+++ b/op_bake.py
@@ -539,6 +539,8 @@ def cycles_bake(mode, padding, sampling_scale, samples, ray_distance, is_multi, 
 
 		# Set samples
 		bpy.context.scene.cycles.samples = samples
+		bpy.context.scene.render.tile_x = 4096
+        	bpy.context.scene.render.tile_y = 4096
 
 		# Speed up samples for simple render modes
 		if modes[mode].type == 'EMIT' or modes[mode].type == 'DIFFUSE':

--- a/op_bake.py
+++ b/op_bake.py
@@ -540,7 +540,7 @@ def cycles_bake(mode, padding, sampling_scale, samples, ray_distance, is_multi, 
 		# Set samples
 		bpy.context.scene.cycles.samples = samples
 		bpy.context.scene.render.tile_x = 4096
-        	bpy.context.scene.render.tile_y = 4096
+		bpy.context.scene.render.tile_y = 4096
 
 		# Speed up samples for simple render modes
 		if modes[mode].type == 'EMIT' or modes[mode].type == 'DIFFUSE':

--- a/utilities_bake.py
+++ b/utilities_bake.py
@@ -167,9 +167,9 @@ def restore_materials():
 				obj.material_slots[index].material = material
 
 				# Face material indexies
-				for face in bm.faces:
-					if face.index in faces:
-						face.material_index = index
+				# for face in bm.faces:
+				#	if face.index in faces:
+				#		face.material_index = index
 
 		# Back to object mode
 		bpy.ops.object.mode_set(mode='OBJECT')


### PR DESCRIPTION
Small tweaks for Baking in cycles.
Cycles render tile settings gives small baking speed increase.
Face material indexes disabled for skipping infinite material restore phase for highpoly mesh (over 5 million tris). Proper polish needed.
Ray distance precision and max limit increase for more convenience.