### PR TITLE
Fix Align Island by Edge only working in Blender 2.83

### DIFF
--- a/op_island_align_edge.py
+++ b/op_island_align_edge.py
@@ -126,8 +126,13 @@ def align_island(uv_vert0, uv_vert1, faces):
 			loop[uv_layers].select = True
 
 	diff = uv_vert1 - uv_vert0
-	current_angle = math.atan2(diff.y, diff.x)
+	current_angle = math.atan2(diff.x, diff.y)
 	angle_to_rotate = round(current_angle / (math.pi/2)) * (math.pi/2) - current_angle
+
+	# For some reason bpy.ops.transform.rotate rotates in the opposite
+	# direction in Blender 2.83 than in other versions.
+	if float(bpy.app.version_string[0:4]) == 2.83:
+		angle_to_rotate = -angle_to_rotate
 
 	bpy.ops.uv.select_linked()
 


### PR DESCRIPTION
My previous patch only fixed this operator in Blender 2.83 because for some reason bpy.ops.transform.rotate rotates in the opposite direction in Blender 2.83 than in other versions. Now it should work in other versions too.

This should fix part of https://github.com/SavMartin/TexTools-Blender/issues/32