### PR TITLE
Texel Density tools update

### DIFF
--- a/op_texel_checker_map.py
+++ b/op_texel_checker_map.py
@@ -38,6 +38,7 @@ class op(bpy.types.Operator):
 
 def assign_checker_map(size_x, size_y):
 	# Force Object mode
+	previous_mode = bpy.context.active_object.mode
 	if bpy.context.view_layer.objects.active != None and bpy.context.object.mode != 'OBJECT':
 		bpy.ops.object.mode_set(mode='OBJECT')
 
@@ -150,7 +151,7 @@ def assign_checker_map(size_x, size_y):
 	# Force redraw of viewport to update texture
 	# bpy.context.scene.update()
 	bpy.context.view_layer.update()
-
+	bpy.ops.object.mode_set(mode=previous_mode)
 
 
 

--- a/op_texel_density_set.py
+++ b/op_texel_density_set.py
@@ -56,7 +56,7 @@ class op(bpy.types.Operator):
 
 def set_texel_density(self, context, mode, density):
 	print("Set texel density!")
-
+	
 	is_edit = bpy.context.object.mode == 'EDIT'
 	is_sync = bpy.context.scene.tool_settings.use_uv_select_sync
 	object_faces = utilities_texel.get_selected_object_faces()
@@ -92,9 +92,6 @@ def set_texel_density(self, context, mode, density):
 			bpy.ops.object.mode_set(mode='EDIT')
 			bpy.context.scene.tool_settings.use_uv_select_sync = False
 
-			# Store selection
-			utilities_uv.selection_store()
-
 			bm = bmesh.from_edit_mesh(obj.data)
 			uv_layers = bm.loops.layers.uv.verify()
 
@@ -103,7 +100,7 @@ def set_texel_density(self, context, mode, density):
 			if is_edit:
 				# Collect selected faces as islands
 				bm.faces.ensure_lookup_table()
-				bpy.ops.uv.select_all(action='SELECT')
+				#bpy.ops.uv.select_all(action='SELECT')
 				group_faces = utilities_uv.getSelectionIslands()
 
 			elif mode == 'ALL':
@@ -111,13 +108,25 @@ def set_texel_density(self, context, mode, density):
 				group_faces = [bm.faces]
 
 			elif mode == 'ISLAND':
-				# Scale each UV idland centered
+				# Scale each UV island centered
 				bpy.ops.mesh.select_all(action='SELECT')
 				bpy.ops.uv.select_all(action='SELECT')
 				group_faces = utilities_uv.getSelectionIslands()
 
 			print("group_faces {}x".format(len(group_faces)))
 
+			#Store selection
+			utilities_uv.selection_store()
+
+			# Set Scale Origin to Island or top left
+			#prepivot = bpy.context.space_data.pivot_point
+			if mode == 'ISLAND':
+				bpy.context.space_data.pivot_point = 'MEDIAN'
+				#bpy.context.tool_settings.transform_pivot_point = 'MEDIAN_POINT'
+			else:
+				bpy.context.space_data.pivot_point = 'CURSOR'
+				#bpy.context.tool_settings.transform_pivot_point = 'CURSOR'
+				bpy.ops.uv.cursor_set(location=(0, 1))
 
 			for group in group_faces:
 				# Get triangle areas
@@ -151,13 +160,6 @@ def set_texel_density(self, context, mode, density):
 				if density > 0 and sum_area_uv > 0 and sum_area_vt > 0:
 					scale = density / (sum_area_uv / sum_area_vt)
 
-				# Set Scale Origin to Island or top left
-				if mode == 'ISLAND':
-					bpy.context.tool_settings.transform_pivot_point = 'MEDIAN_POINT'
-				elif mode == 'ALL':
-					bpy.context.tool_settings.transform_pivot_point = 'CURSOR'
-					bpy.ops.uv.cursor_set(location=(0, 1))
-
 				# Select Face loops and scale
 				bpy.ops.uv.select_all(action='DESELECT')
 				bpy.context.scene.tool_settings.uv_select_mode = 'VERTEX'
@@ -170,6 +172,7 @@ def set_texel_density(self, context, mode, density):
 
 			# Restore selection
 			utilities_uv.selection_restore()
+			#bpy.context.space_data.pivot_point = prepivot
 
 	# Restore selection
 	bpy.ops.object.mode_set(mode='OBJECT')

--- a/utilities_texel.py
+++ b/utilities_texel.py
@@ -66,7 +66,7 @@ def get_object_texture_image(obj):
 							if node.image:
 								return node.image
 
-	
+	bpy.ops.object.mode_set(mode=previous_mode)
 
 	return None
 

--- a/utilities_uv.py
+++ b/utilities_uv.py
@@ -18,7 +18,8 @@ def selection_store():
 	# https://blender.stackexchange.com/questions/5781/how-to-list-all-selected-elements-in-python
 	# print("selectionStore")
 	settings.selection_uv_mode = bpy.context.scene.tool_settings.uv_select_mode
-	settings.selection_uv_pivot = bpy.context.tool_settings.transform_pivot_point
+	#settings.selection_uv_pivot = bpy.context.tool_settings.transform_pivot_point
+	settings.selection_uv_pivot = bpy.context.space_data.pivot_point
 	
 	settings.selection_uv_pivot_pos = bpy.context.space_data.cursor_location.copy()
 
@@ -56,7 +57,8 @@ def selection_restore(bm = None, uv_layers = None):
 
 	# print("selectionRestore")
 	bpy.context.scene.tool_settings.uv_select_mode = settings.selection_uv_mode
-	bpy.context.tool_settings.transform_pivot_point = settings.selection_uv_pivot
+	#bpy.context.tool_settings.transform_pivot_point = settings.selection_uv_pivot
+	bpy.context.space_data.pivot_point = settings.selection_uv_pivot
 
 	contextViewUV = utilities_ui.GetContextViewUV()
 	if contextViewUV:


### PR DESCRIPTION
fix #13
Some QOL changes in related "checker map" setter, previous mode (object/edit) wasn't restored in certain scenarios.
In Utilities_uv, I made a change regarding the restoration of the pivor point in uv space. It's not the first time I find "context.tool_settings.transform_pivot_point" doesn't work in UV space, although recommended, I think it's intended por 3D view only. Maybe this change can be problematic if any operator using those store/restore functions is invoked outside UV space, but as far as I can tell, the operators using it have poll functions that don't allow that.