### PR TITLE
Fixed variable name collision with built-in "set"

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -362,19 +362,19 @@ class UV_OT_op_select_bake_set(Operator):
 	def execute(self, context):
 		print("Set: "+self.select_set)
 		if self.select_set != "":
-			for set in settings.sets:
-				if set.name == self.select_set:
+			for bset in settings.sets:
+				if bset.name == self.select_set:
 					# Select this entire set
 					bpy.ops.object.select_all(action='DESELECT')
-					for obj in set.objects_low:
+					for obj in bset.objects_low:
 						obj.select_set( state = True, view_layer = None)
-					for obj in set.objects_high:
+					for obj in bset.objects_high:
 						obj.select_set( state = True, view_layer = None)
-					for obj in set.objects_cage:
+					for obj in bset.objects_cage:
 						obj.select_set( state = True, view_layer = None)
 					# Set active object to low poly to better visualize high and low wireframe color
-					if len(set.objects_low) > 0:
-						bpy.context.view_layer.objects.active = set.objects_low[0]
+					if len(bset.objects_low) > 0:
+						bpy.context.view_layer.objects.active = bset.objects_low[0]
 
 					break
 		return {'FINISHED'}
@@ -394,20 +394,20 @@ class UV_OT_op_select_bake_type(Operator):
 
 	def execute(self, context):
 		objects = []
-		for set in settings.sets:
+		for bset in settings.sets:
 			if self.select_type == 'low':
-				objects+=set.objects_low
+				objects+=bset.objects_low
 			elif self.select_type == 'high':
-				objects+=set.objects_high
+				objects+=bset.objects_high
 			elif self.select_type == 'cage':
-				objects+=set.objects_cage
+				objects+=bset.objects_cage
 			elif self.select_type == 'float':
-				objects+=set.objects_float
-			elif self.select_type == 'issue' and set.has_issues:
-				objects+=set.objects_low
-				objects+=set.objects_high
-				objects+=set.objects_cage
-				objects+=set.objects_float
+				objects+=bset.objects_float
+			elif self.select_type == 'issue' and bset.has_issues:
+				objects+=bset.objects_low
+				objects+=bset.objects_high
+				objects+=bset.objects_cage
+				objects+=bset.objects_float
 
 		bpy.ops.object.select_all(action='DESELECT')
 		for obj in objects:
@@ -1168,8 +1168,8 @@ class UI_PT_Panel_Bake(Panel):
 
 		# Optional Parameters
 		col.separator()
-		for set in settings.sets:
-			if len(set.objects_high) > 0 and len(set.objects_low) > 0:
+		for bset in settings.sets:
+			if len(bset.objects_high) > 0 and len(bset.objects_low) > 0:
 				col.prop(context.scene.texToolsSettings, "bake_cage_extrusion")
 				if settings.bversion >= 2.90:
 					col.prop(context.scene.texToolsSettings, "bake_ray_distance")
@@ -1213,16 +1213,16 @@ class UI_PT_Panel_Bake(Panel):
 			count_types = {
 				'low':0, 'high':0, 'cage':0, 'float':0, 'issue':0, 
 			}
-			for set in settings.sets:
-				if set.has_issues:
+			for bset in settings.sets:
+				if bset.has_issues:
 					count_types['issue']+=1
-				if len(set.objects_low) > 0:
+				if len(bset.objects_low) > 0:
 					count_types['low']+=1
-				if len(set.objects_high) > 0:
+				if len(bset.objects_high) > 0:
 					count_types['high']+=1
-				if len(set.objects_cage) > 0:
+				if len(bset.objects_cage) > 0:
 					count_types['cage']+=1
-				if len(set.objects_float) > 0:
+				if len(bset.objects_float) > 0:
 					count_types['float']+=1
 
 			# Freeze Selection
@@ -1258,39 +1258,38 @@ class UI_PT_Panel_Bake(Panel):
 				split = row.split(factor=0.55)
 
 			c = split.column(align=True)
-			for s in range(0, len(settings.sets)):
-				set = settings.sets[s]
+			for s,bset in enumerate(settings.sets):
 				r = c.row(align=True)
 				r.active = not (bpy.context.scene.texToolsSettings.bake_force_single and s > 0)
 
-				if set.has_issues:
-					r.operator("uv.op_select_bake_set", text=set.name, icon='ERROR').select_set = set.name 
+				if bset.has_issues:
+					r.operator("uv.op_select_bake_set", text=bset.name, icon='ERROR').select_set = bset.name 
 				else:
-					r.operator("uv.op_select_bake_set", text=set.name).select_set = set.name 
+					r.operator("uv.op_select_bake_set", text=bset.name).select_set = bset.name 
 
 
 			c = split.column(align=True)
-			for set in settings.sets:
+			for bset in settings.sets:
 				r = c.row(align=True)
 				r.alignment = "LEFT"
 
-				if len(set.objects_low) > 0:
-					r.label(text="{}".format(len(set.objects_low)), icon_value = icon_get("bake_obj_low"))
+				if len(bset.objects_low) > 0:
+					r.label(text="{}".format(len(bset.objects_low)), icon_value = icon_get("bake_obj_low"))
 				elif count_types['low'] > 0:
 					r.label(text="")
 
-				if len(set.objects_high) > 0:
-					r.label(text="{}".format(len(set.objects_high)), icon_value = icon_get("bake_obj_high"))
+				if len(bset.objects_high) > 0:
+					r.label(text="{}".format(len(bset.objects_high)), icon_value = icon_get("bake_obj_high"))
 				elif count_types['high'] > 0:
 					r.label(text="")
 
-				if len(set.objects_float) > 0:
-					r.label(text="{}".format(len(set.objects_float)), icon_value = icon_get("bake_obj_float"))
+				if len(bset.objects_float) > 0:
+					r.label(text="{}".format(len(bset.objects_float)), icon_value = icon_get("bake_obj_float"))
 				elif count_types['float'] > 0:
 					r.label(text="")
 
-				if len(set.objects_cage) > 0:
-					r.label(text="{}".format(len(set.objects_cage)), icon_value = icon_get("bake_obj_cage"))
+				if len(bset.objects_cage) > 0:
+					r.label(text="{}".format(len(bset.objects_cage)), icon_value = icon_get("bake_obj_cage"))
 				elif count_types['cage'] > 0:
 					r.label(text="")
 

--- a/op_bake_explode.py
+++ b/op_bake_explode.py
@@ -34,13 +34,13 @@ def explode(self):
 	set_bounds = {}
 	set_volume = {}
 	avg_side = 0
-	for set in sets:
-		set_bounds[set] = get_bbox_set(set)
-		set_volume[set] = set_bounds[set]['size'].x * set_bounds[set]['size'].y * set_bounds[set]['size'].z
+	for bset in sets:
+		set_bounds[bset] = get_bbox_set(bset)
+		set_volume[bset] = set_bounds[bset]['size'].x * set_bounds[bset]['size'].y * set_bounds[bset]['size'].z
 
-		avg_side+=set_bounds[set]['size'].x
-		avg_side+=set_bounds[set]['size'].y
-		avg_side+=set_bounds[set]['size'].z
+		avg_side+=set_bounds[bset]['size'].x
+		avg_side+=set_bounds[bset]['size'].y
+		avg_side+=set_bounds[bset]['size'].z
 
 	avg_side/=(len(sets)*3)
 
@@ -62,16 +62,16 @@ def explode(self):
 	bpy.context.scene.frame_current = 0
 	
 	# Process each set
-	for set in sorted_sets:
-		if set_bounds[set] != bbox_max:
-			delta = set_bounds[set]['center'] - bbox_all['center']
-			offset_set(set, delta, avg_side*0.35, dir_offset_last_bbox )
+	for bset in sorted_sets:
+		if set_bounds[bset] != bbox_max:
+			delta = set_bounds[bset]['center'] - bbox_all['center']
+			offset_set(bset, delta, avg_side*0.35, dir_offset_last_bbox )
 
 
 
-def offset_set(set, delta, margin, dir_offset_last_bbox):
-	objects = set.objects_low + set.objects_high + set.objects_cage
-	# print("\nSet '{}' with {}x".format(set.name, len(objects) ))
+def offset_set(bset, delta, margin, dir_offset_last_bbox):
+	objects = bset.objects_low + bset.objects_high + bset.objects_cage
+	# print("\nSet '{}' with {}x".format(bset.name, len(objects) ))
 
 	# Which Direction?
 	delta_max = max(abs(delta.x), abs(delta.y), abs(delta.z))
@@ -92,7 +92,7 @@ def offset_set(set, delta, margin, dir_offset_last_bbox):
 	key = get_delta_key(delta)
 
 	# Calculate Offset
-	bbox = get_bbox_set(set)
+	bbox = get_bbox_set(bset)
 	bbox_last = dir_offset_last_bbox[key]
 	
 	offset = Vector((0,0,0))
@@ -134,7 +134,7 @@ def offset_set(set, delta, margin, dir_offset_last_bbox):
 		obj.keyframe_insert(data_path="location")
 
 	# Update last bbox in direction
-	dir_offset_last_bbox[key] = get_bbox_set(set)
+	dir_offset_last_bbox[key] = get_bbox_set(bset)
 
 
 
@@ -178,8 +178,8 @@ def merge_bounds(bounds):
 
 
 
-def get_bbox_set(set):
-	objects = set.objects_low + set.objects_high + set.objects_cage
+def get_bbox_set(bset):
+	objects = bset.objects_low + bset.objects_high + bset.objects_cage
 	bounds = []
 	for obj in objects:
 		bounds.append( get_bbox(obj) )

--- a/utilities_bake.py
+++ b/utilities_bake.py
@@ -75,14 +75,14 @@ def store_bake_settings():
 	# Disable Objects that are meant to be hidden
 	sets = settings.sets
 	objects_sets = []
-	for set in sets:
-		for obj in set.objects_low:
+	for bset in sets:
+		for obj in bset.objects_low:
 			if obj not in objects_sets:
 				objects_sets.append(obj)
-		for obj in set.objects_high:
+		for obj in bset.objects_high:
 			if obj not in objects_sets:
 				objects_sets.append(obj)
-		for obj in set.objects_cage:
+		for obj in bset.objects_cage:
 			if obj not in objects_sets:
 				objects_sets.append(obj)
 
@@ -229,8 +229,8 @@ def get_object_type(obj):
 
 def get_baked_images(sets):
 	images = []
-	for set in sets:
-		name_texture = "{}_".format(set.name)
+	for bset in sets:
+		name_texture = "{}_".format(bset.name)
 		for image in bpy.data.images:
 			if name_texture in image.name:
 				images.append(image)


### PR DESCRIPTION
- Changed variable name "set" to "bset" so it wouldn't clobber Python's built-in "set" function.
  - set() is used many times in other places in the codebase as well so this should prevent future problems in those scopes.

- Also changed 2 uses of range(0,len()) to enumerate() as its more pythonic, more terse, and does the same thing.