### PR TITLE
Nicer arrows for the UV Layout panel

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -932,9 +932,9 @@ class UI_PT_Panel_Layout(Panel):
 		row = col_tr.row(align=True)
 		col = row.column(align=True)
 		# col.label(text="")
-		col.operator(op_align.op.bl_idname, text="←↑", icon_value = icon_get("op_align_topleft")).direction = "topleft"
+		col.operator(op_align.op.bl_idname, text="↖", icon_value = icon_get("op_align_topleft")).direction = "topleft"
 		col.operator(op_align.op.bl_idname, text="← ", icon_value = icon_get("op_align_left")).direction = "left"
-		col.operator(op_align.op.bl_idname, text="←↓", icon_value = icon_get("op_align_bottomleft")).direction = "bottomleft"
+		col.operator(op_align.op.bl_idname, text="↙", icon_value = icon_get("op_align_bottomleft")).direction = "bottomleft"
 		
 		col = row.column(align=True)
 		col.operator(op_align.op.bl_idname, text="↑", icon_value = icon_get("op_align_top")).direction = "top"

--- a/__init__.py
+++ b/__init__.py
@@ -943,9 +943,9 @@ class UI_PT_Panel_Layout(Panel):
 
 		col = row.column(align=True)
 		# col.label(text="")
-		col.operator(op_align.op.bl_idname, text="↑→", icon_value = icon_get("op_align_topright")).direction = "topright"
+		col.operator(op_align.op.bl_idname, text="↗", icon_value = icon_get("op_align_topright")).direction = "topright"
 		col.operator(op_align.op.bl_idname, text=" →", icon_value = icon_get("op_align_right")).direction = "right"
-		col.operator(op_align.op.bl_idname, text="↓→", icon_value = icon_get("op_align_bottomright")).direction = "bottomright"
+		col.operator(op_align.op.bl_idname, text="↘", icon_value = icon_get("op_align_bottomright")).direction = "bottomright"
 
 		row_tr = col_tr.row(align=True)
 		col = row_tr.column(align=True)


### PR DESCRIPTION
hey there, I thought the style of diagonal arrows is a bit clumpsy - just a simple tweak

Should look like this:
![grafik](https://user-images.githubusercontent.com/13512160/136710341-8edc5987-8813-453a-9f1c-d6bb084bb20d.png)
