### PR TITLE
Align 2d Cursor

### DIFF
--- a/op_align.py
+++ b/op_align.py
@@ -89,9 +89,9 @@ def align_cursor(context, align_mode, direction, boundsAll=None, column=0, row=0
 	elif direction == "center":
 		context.space_data.cursor_location = boundsAll['center']
 	elif direction == "horizontal":
-		context.space_data.cursor_location[0] = boundsAll['center'].x
-	elif direction == "vertical":
 		context.space_data.cursor_location[1] = boundsAll['center'].y
+	elif direction == "vertical":
+		context.space_data.cursor_location[0] = boundsAll['center'].x
 	elif direction == "bottomleft":
 		context.space_data.cursor_location[1] = boundsAll['min'].y
 		context.space_data.cursor_location[0] = boundsAll['min'].x

--- a/op_align.py
+++ b/op_align.py
@@ -9,10 +9,13 @@ from . import utilities_uv
 class op(bpy.types.Operator):
 	bl_idname = "uv.textools_align"
 	bl_label = "Align"
-	bl_description = "Align vertices, edges or shells"
+	bl_description = "Align vertices, edges or shells.\nHold Alt to align the cursor.\nHold Ctrl to force Selection Mode.\nHold Shift to force Canvas mode"
 	bl_options = {'REGISTER', 'UNDO'}
 	
-	direction : bpy.props.StringProperty(name="Direction", default="top")
+	direction: bpy.props.StringProperty(name="Direction", default="top")
+	align_mode: bpy.props.StringProperty(name="Align Mode", default="SELECTION")
+	align_cursor: bpy.props.BoolProperty(name="Align Cursor", default=False)
+
 
 	@classmethod
 	def poll(cls, context):
@@ -28,25 +31,81 @@ class op(bpy.types.Operator):
 			return False
 		return True
 
+	def invoke(self, context, event):
+
+		self.align_mode = bpy.context.scene.texToolsSettings.align_mode
+		
+		self.align_cursor = event.alt
+
+		if event.shift:
+			self.align_mode = 'CANVAS'
+		elif event.ctrl:
+			self.align_mode = 'SELECTION'
+
+		self.execute(context)
+		return {'FINISHED'}
+
 
 	def execute(self, context):
-		align_mode = bpy.context.scene.texToolsSettings.align_mode
 
-		if align_mode == 'SELECTION':
+		if self.align_mode == 'SELECTION':
 			all_ob_bounds = utilities_uv.multi_object_loop(utilities_uv.getSelectionBBox, need_results=True)
 			if not any(all_ob_bounds):
 				return {'CANCELLED'}
 
 			boundsAll = utilities_uv.get_BBOX_multi(all_ob_bounds)
 
-			utilities_uv.multi_object_loop(align, context, align_mode, self.direction, boundsAll=boundsAll)
-		
+			if self.align_cursor:
+				align_cursor(context, self.align_mode, self.direction, boundsAll)	
+			else:
+				utilities_uv.multi_object_loop(align, context, self.align_mode, self.direction, boundsAll=boundsAll)
 		else:
 			udim_tile, column, row = utilities_uv.get_UDIM_tile_coords(bpy.context.active_object)
-			utilities_uv.multi_object_loop(align, context, align_mode, self.direction, column=column, row=row)
+			
+			if self.align_cursor:
+				align_cursor(context, self.align_mode, self.direction, column=column, row=row)
+			else:
+				utilities_uv.multi_object_loop(align, context, self.align_mode, self.direction, column=column, row=row)
 		
 		return {'FINISHED'}
 
+
+def align_cursor(context, align_mode, direction, boundsAll=None, column=0, row=0):
+
+	if not boundsAll:
+		boundsAll = {}
+		boundsAll["min"] = Vector((column, row))
+		boundsAll["max"] = Vector((column + 1, row + 1))
+		boundsAll["center"] = Vector((column + 0.5, row + 0.5))
+
+	if direction == "bottom":
+		context.space_data.cursor_location[1] = boundsAll['min'].y
+	elif direction == "top":
+		context.space_data.cursor_location[1] = boundsAll['max'].y
+	elif direction == "left":
+		context.space_data.cursor_location[0] = boundsAll['min'].x
+	elif direction == "right":
+		context.space_data.cursor_location[0] = boundsAll['max'].x
+	elif direction == "center":
+		context.space_data.cursor_location = boundsAll['center']
+	elif direction == "horizontal":
+		context.space_data.cursor_location[0] = boundsAll['center'].x
+	elif direction == "vertical":
+		context.space_data.cursor_location[1] = boundsAll['center'].y
+	elif direction == "bottomleft":
+		context.space_data.cursor_location[1] = boundsAll['min'].y
+		context.space_data.cursor_location[0] = boundsAll['min'].x
+	elif direction == "topright":
+		context.space_data.cursor_location[1] = boundsAll['max'].y
+		context.space_data.cursor_location[0] = boundsAll['max'].x
+	elif direction == "topleft":
+		context.space_data.cursor_location[1] = boundsAll['max'].y
+		context.space_data.cursor_location[0] = boundsAll['min'].x
+	elif direction == "bottomright":
+		context.space_data.cursor_location[1] = boundsAll['min'].y
+		context.space_data.cursor_location[0] = boundsAll['max'].x
+	else:
+		print("Unknown direction: "+str(direction))
 
 
 def align(context, align_mode, direction, boundsAll={}, column=0, row=0):


### PR DESCRIPTION
This patch extends the align operator a bit - such that one can easily snap the 2d cursor or switch the align mode temporarily.

This allows for a faster and more fluid workflow, as one doesnt need to fiddle around with the dropdown menu, or change selections to place the cursor onto a vertex.

Code changes should be easy to follow, nothing complicated going on :)

