### PR TITLE
FIX #125: Convert samples to int

### DIFF
--- a/op_bake.py
+++ b/op_bake.py
@@ -195,7 +195,7 @@ class op(bpy.types.Operator):
 
 			bake_single = bpy.context.scene.texToolsSettings.bake_force_single,
 			sampling_scale = int(bpy.context.scene.texToolsSettings.bake_sampling),
-			samples = bpy.context.scene.texToolsSettings.bake_samples,
+			samples = int(bpy.context.scene.texToolsSettings.bake_samples),
 			cage_extrusion = bpy.context.scene.texToolsSettings.bake_cage_extrusion,
 			ray_distance = bpy.context.scene.texToolsSettings.bake_ray_distance,
 			circular_report = circular_report,


### PR DESCRIPTION
Update script to work with Blender 3.1, Blender now uses int instead of float for Cycles Samples