### PR TITLE
Speedup x200 calc uv islands and add bbox module and apply new tools to Sort Align operator

### DIFF
--- a/op_island_align_sort.py
+++ b/op_island_align_sort.py
@@ -64,10 +64,10 @@ class op(bpy.types.Operator):
 				margin_y += self.padding + bbox.height
 		else:
 			margin_x = general_bbox.xmin
-			margin_y = general_bbox.ymax
+			margin_y = general_bbox.ymin
 
 			for island, bbox, uv_layer in all_groups:
-				delta = Vector((margin_x, margin_y)) - bbox.left_upper
+				delta = Vector((margin_x, margin_y)) - bbox.min
 				utilities_uv.translate_island(island, uv_layer, delta)
 				margin_x += self.padding + bbox.width
 

--- a/op_island_align_sort.py
+++ b/op_island_align_sort.py
@@ -1,11 +1,9 @@
 import bpy
 import bmesh
 
-from itertools import chain
 from mathutils import Vector
 from . import utilities_uv
-
-
+from .utilities_bbox import BBox
 
 class op(bpy.types.Operator):
 	bl_idname = "uv.textools_island_align_sort"
@@ -13,8 +11,9 @@ class op(bpy.types.Operator):
 	bl_description = "Rotate UV islands to minimal bounds and sort them horizontally or vertically"
 	bl_options = {'REGISTER', 'UNDO'}
 
-	is_vertical : bpy.props.BoolProperty(description="Vertical or Horizontal orientation", default=True)
-	padding : bpy.props.FloatProperty(description="Padding between UV islands", default=0.05)
+	is_vertical: bpy.props.BoolProperty(name='Vertical', description="Vertical or Horizontal orientation", default=True)
+	align: bpy.props.BoolProperty(name='Align', description="Align Island orientation", default=True)
+	padding: bpy.props.FloatProperty(name='Padding', description="Padding between UV islands", default=0.05)
 
 	@classmethod
 	def poll(cls, context):
@@ -28,106 +27,54 @@ class op(bpy.types.Operator):
 			return False
 		if not bpy.context.object.data.uv_layers:
 			return False
-		if bpy.context.scene.tool_settings.use_uv_select_sync:
-			return False
 		return True
 
-
 	def execute(self, context):
-		all_ob_bounds = utilities_uv.multi_object_loop(main, context, self.is_vertical, self.padding, need_results=True)
+		general_bbox = BBox()
+		all_groups = []
+		bmeshes = [] # bmesh objects must be saved, otherwise they will disappear from the scope and cause an error
+		selected_objs = utilities_uv.selected_unique_objects_in_mode_with_uv()
+		for obj in selected_objs:
+			bm = bmesh.from_edit_mesh(obj.data)
+			uv_layer = bm.loops.layers.uv.verify()
+			islands = utilities_uv.get_selected_islands(bm, uv_layer, selected=False, extend_selection_to_islands=True)
+			if not islands:
+				continue
+			for i, island in enumerate(islands):
+				bbox_pre = BBox.calc_bbox_uv(island, uv_layer)
+				general_bbox.union(bbox_pre)
+				if self.align:
+					angle = utilities_uv.calc_min_align_angle(island, uv_layer)
+					utilities_uv.rotate_island(island, uv_layer, angle)
 
-		if not any(all_ob_bounds):
-			return {'CANCELLED'}
+				bbox = BBox.calc_bbox_uv(island, uv_layer) if self.align else bbox_pre
+				all_groups.append((island, bbox, uv_layer))
+			bmeshes.append(bm)
 
-		utilities_uv.multi_object_loop(relocate, context, self.is_vertical, self.padding, all_ob_bounds, ob_num=0)
-		return {'FINISHED'}
+		all_groups.sort(key=lambda x: x[1].max_lenght, reverse=True)
 
+		# transform
+		if self.is_vertical:
+			margin_x = general_bbox.xmin
+			margin_y = general_bbox.ymin
 
-
-def main(context, isVertical, padding):
-	bm = bmesh.from_edit_mesh(bpy.context.active_object.data)
-	uv_layers = bm.loops.layers.uv.verify()
-
-	selected_faces = {face for face in bm.faces if any([loop[uv_layers].select for loop in face.loops]) and face.select}
-	if not selected_faces:
-		return {}
-
-	boundsAll = utilities_uv.get_BBOX(selected_faces, bm, uv_layers)
-	islands = utilities_uv.getSelectionIslands(bm, uv_layers, extend_selection_to_islands=True, selected_faces=selected_faces)
-	allSizes = {}
-	allBounds = {}
-
-	#Rotate to minimal bounds
-	for i, island in enumerate(islands):
-		utilities_uv.alignMinimalBounds(bm, uv_layers, island)
-
-		#Collect BBox sizes
-		bounds = utilities_uv.get_BBOX(island, bm, uv_layers)
-		allSizes[i] = max(bounds['width'], bounds['height']) + i*0.000001	#Make each size unique
-		allBounds[i] = bounds
-
-	#Position by sorted size in row
-	sortedSizes = sorted(allSizes.items(), key=lambda x: x[1], reverse=True)	#Sort by values, store tuples
-	offset = 0.0
-	for sortedSize in sortedSizes:
-		index = sortedSize[0]
-		island = islands[index]
-		bounds = allBounds[index]
-
-		#Offset Island
-		delta = Vector((boundsAll['min'].x - bounds['min'].x, boundsAll['max'].y - bounds['max'].y))
-		if(isVertical):
-			for face in island:
-				for loop in face.loops:
-					loop[uv_layers].uv += Vector((delta.x, delta.y-offset))
-			offset += bounds['height'] + padding
+			for island, bbox, uv_layer in all_groups:
+				delta = Vector((margin_x, margin_y)) - bbox.left_bottom
+				utilities_uv.translate_island(island, uv_layer, delta)
+				margin_y += self.padding + bbox.height
 		else:
-			for face in island:
-				for loop in face.loops:
-					loop[uv_layers].uv += Vector((delta.x+offset, delta.y))
-			offset += bounds['width'] + padding
+			margin_x = general_bbox.xmin
+			margin_y = general_bbox.ymax
 
-	return utilities_uv.get_BBOX(chain.from_iterable(islands), bm, uv_layers)
+			for island, bbox, uv_layer in all_groups:
+				delta = Vector((margin_x, margin_y)) - bbox.left_upper
+				utilities_uv.translate_island(island, uv_layer, delta)
+				margin_x += self.padding + bbox.width
 
+		for obj in selected_objs:
+			bmesh.update_edit_mesh(obj.data)
 
-
-def relocate(context, isVertical, padding, all_ob_bounds, ob_num=0):
-	selection_mode = bpy.context.scene.tool_settings.uv_select_mode
-	bm = bmesh.from_edit_mesh(bpy.context.active_object.data)
-	uv_layers = bm.loops.layers.uv.verify()
-
-	islands = utilities_uv.getSelectionIslands(bm, uv_layers, extend_selection_to_islands=True)
-
-	if ob_num > 0 :
-		if all_ob_bounds[ob_num]:
-			offset = 0.0
-			origin = Vector((0,0))
-			for i in range(0, ob_num):
-				if all_ob_bounds[i]:
-					if isVertical:
-						offset += all_ob_bounds[i]['height'] + padding
-					else:
-						offset += all_ob_bounds[i]['width'] + padding
-			for i in range(0, ob_num+1):
-				if all_ob_bounds[i]:
-					origin.x = all_ob_bounds[i]['min'].x
-					origin.y = all_ob_bounds[i]['max'].y
-					break
-
-			delta = Vector((origin.x - all_ob_bounds[ob_num]['min'].x, origin.y - all_ob_bounds[ob_num]['max'].y))
-			if isVertical:
-				for island in islands:
-					for face in island:
-						for loop in face.loops:
-							loop[uv_layers].uv += Vector((delta.x, delta.y-offset))
-			else:
-				for island in islands:
-					for face in island:
-						for loop in face.loops:
-							loop[uv_layers].uv += Vector((delta.x+offset, delta.y))
-	# Workaround for selection not flushing properly from loops to EDGE Selection Mode, apparently since UV edge selection support was added to the UV space
-	bpy.ops.uv.select_mode(type='VERTEX')
-	bpy.context.scene.tool_settings.uv_select_mode = selection_mode
+		return {'FINISHED'}
 
 
 bpy.utils.register_class(op)

--- a/op_uv_unwrap.py
+++ b/op_uv_unwrap.py
@@ -122,8 +122,8 @@ def main(context, axis):
         axis_y_current = y_min.uv - y_max.uv
         current_y_angle = up.angle_signed(axis_y_current)
 
-        angle_x = current_x_angle - intial_x_angle
-        angle_y = current_y_angle - intial_y_angle
+        angle_x = intial_x_angle - current_x_angle
+        angle_y = intial_y_angle - current_y_angle
         angle = min(angle_x, angle_y)
 
         center = island_bbox['center']

--- a/op_uv_unwrap.py
+++ b/op_uv_unwrap.py
@@ -127,7 +127,7 @@ def main(context, axis):
         angle = min(angle_x, angle_y)
 
         center = island_bbox['center']
-        utilities_uv.rotate_island(island, uv_layer, angle, center.x, center.y)
+        utilities_uv.rotate_island(island, uv_layer, angle, center)
 
         #keep it the same size
         scale_x = intial_x_axis.length / axis_x_current.length 

--- a/utilities_bbox.py
+++ b/utilities_bbox.py
@@ -1,0 +1,189 @@
+import math
+from mathutils import Vector
+
+
+class BBox:
+    @classmethod
+    def calc_bbox(cls, coords):
+        xmin = math.inf
+        xmax = -math.inf
+        ymin = math.inf
+        ymax = -math.inf
+
+        for x, y in coords:
+            if x < xmin:
+                xmin = x
+            if x > xmax:
+                xmax = x
+            if y < ymin:
+                ymin = y
+            if y > ymax:
+                ymax = y
+        return cls(xmin, xmax, ymin, ymax)
+
+    @classmethod
+    def calc_bbox_uv(cls, group, uv_layers, are_loops=False):
+        xmin = math.inf
+        xmax = -math.inf
+        ymin = math.inf
+        ymax = -math.inf
+
+        if not are_loops:
+            for face in group:
+                for loop in face.loops:
+                    x, y = loop[uv_layers].uv
+                    if xmin > x:
+                        xmin = x
+                    if xmax < x:
+                        xmax = x
+                    if ymin > y:
+                        ymin = y
+                    if ymax < y:
+                        ymax = y
+        else:
+            for loop in group:
+                x, y = loop[uv_layers].uv
+                if xmin > x:
+                    xmin = x
+                if xmax < x:
+                    xmax = x
+                if ymin > y:
+                    ymin = y
+                if ymax < y:
+                    ymax = y
+        return cls(xmin, xmax, ymin, ymax)
+
+    @classmethod
+    def init_from_minmax(cls, min, max):
+        bbox = cls(min[0], max[0], min[1], max[1])
+        bbox.sanitize()
+        return bbox
+
+    def __init__(self, xmin=math.inf, xmax=-math.inf, ymin=math.inf, ymax=-math.inf):
+        self.xmin = xmin
+        self.xmax = xmax
+        self.ymin = ymin
+        self.ymax = ymax
+
+    def __str__(self):
+        return f"xmin={self.xmin:.6}, xmax={self.xmax:.6}, ymin={self.ymin:.6}, ymax={self.ymax:.6}, width={self.width:.6}, height={self.height:.6}"
+
+    @property
+    def is_valid(self) -> bool:
+        return (self.xmin <= self.xmax) and (self.ymin <= self.ymax)
+
+    @property
+    def max(self):
+        return Vector((self.xmax, self.ymax))
+
+    @property
+    def min(self):
+        return Vector((self.xmin, self.ymin))
+
+    @property
+    def left_upper(self):
+        return Vector((self.xmin, self.ymax))
+
+    @property
+    def left_bottom(self):
+        return Vector((self.xmin, self.ymin))
+
+    @property
+    def right_bottom(self):
+        return Vector((self.xmax, self.ymin))
+
+    @property
+    def right_upper(self):
+        return Vector((self.xmax, self.ymax))
+
+    @property
+    def upper(self):
+        return Vector(((self.xmin + self.xmax) * 0.5, self.ymax))
+
+    @property
+    def bottom(self):
+        return Vector(((self.xmin + self.xmax) * 0.5, self.ymin))
+
+    @property
+    def left(self):
+        return Vector((self.xmin, (self.ymin + self.ymax) * 0.5))
+
+    @property
+    def right(self):
+        return Vector((self.xmax, (self.ymin + self.ymax) * 0.5))
+
+    @property
+    def center(self):
+        return Vector(((self.xmin + self.xmax) * 0.5, (self.ymin + self.ymax) * 0.5))
+
+    @property
+    def width(self) -> float:
+        return self.xmax - self.xmin
+
+    @property
+    def height(self) -> float:
+        return self.ymax - self.ymin
+
+    @property
+    def max_lenght(self):
+        return max(self.width, self.height)
+
+    @property
+    def min_lenght(self):
+        return min(self.width, self.height)
+
+    @property
+    def half_width(self) -> float:
+        return (self.xmax - self.xmin) * 0.5
+
+    @property
+    def half_height(self) -> float:
+        return (self.ymax - self.ymin) * 0.5
+
+    @property
+    def area(self):
+        return self.width * self.height
+
+    @property
+    def is_empty(self) -> bool:
+        return (self.xmax <= self.xmin) or (self.ymax <= self.ymin)
+
+    def union(self, other):
+        if self.xmin > other.xmin:
+            self.xmin = other.xmin
+        if self.xmax < other.xmax:
+            self.xmax = other.xmax
+        if self.ymin > other.ymin:
+            self.ymin = other.ymin
+        if self.ymax < other.ymax:
+            self.ymax = other.ymax
+        return self
+
+    def sanitize(self):
+        if self.xmin > self.xmax:
+            self.xmin, self.xmax = self.xmax, self.xmin
+        if self.ymin > self.ymax:
+            self.ymin, self.ymax = self.ymax, self.ymin
+        # assert self.is_valid
+        return self
+
+    def do_minmax_v(self, xy):
+        if xy[0] < self.xmin:
+            self.xmin = xy[0]
+        if xy[0] > self.xmax:
+            self.xmax = xy[0]
+        if xy[1] < self.ymin:
+            self.ymin = xy[1]
+        if xy[1] > self.ymax:
+            self.ymax = xy[1]
+
+    def update(self, coords):
+        for x, y in coords:
+            if x < self.xmin:
+                self.xmin = x
+            if x > self.xmax:
+                self.xmax = x
+            if y < self.ymin:
+                self.ymin = y
+            if y > self.ymax:
+                self.ymax = y


### PR DESCRIPTION
These are milestone changes, after which the addon will have fewer crutches, less code, and more speed of execution and fewer limitations.

Function get_selected_islands - as much as possible, effectively calculates islands, without requiring various manipulations with built-in operators.

Many functions related to bbox also need to be gradually moved to the appropriate module, as well as get rid of some code duplication.

The bbox module is very convenient to work with, there is no need to calculate (in vain) different values, they can be calculated through properties. And accessing these properties is more convenient than using dict and probably faster.