### PR TITLE
Makes uv_unwrap available to Repeat Last

### DIFF
--- a/op_uv_unwrap.py
+++ b/op_uv_unwrap.py
@@ -11,7 +11,7 @@ class op(bpy.types.Operator):
     bl_idname = "uv.textools_uv_unwrap"
     bl_label = "Unwrap"
     bl_description = "Unwrap selected UVs"
-    bl_options = {'UNDO'}
+    bl_options = {'REGISTER', 'UNDO'}
 
     axis: bpy.props.StringProperty(name="axis", default="xy")
 


### PR DESCRIPTION
- Simple addition to `bl_options` that makes `uv.textools_uv_unwrap` available to Blender's Repeat Last operator.