### PR TITLE
Refactor Flipped

### DIFF
--- a/op_select_islands_flipped.py
+++ b/op_select_islands_flipped.py
@@ -4,7 +4,6 @@ import bmesh
 from . import utilities_uv
 
 
-
 class op(bpy.types.Operator):
 	bl_idname = "uv.textools_select_islands_flipped"
 	bl_label = "Select Flipped"
@@ -25,46 +24,50 @@ class op(bpy.types.Operator):
 			return False
 		return True
 
-
 	def execute(self, context):
-		utilities_uv.multi_object_loop(select_flipped, context)
-		return {'FINISHED'}
+		return select_flipped(self)
 
-
-
-def select_flipped(context):
-	obj = bpy.context.active_object
-	bm = bmesh.from_edit_mesh(obj.data)
-	uv_layers = bm.loops.layers.uv.verify()
-	sync = bpy.context.scene.tool_settings.use_uv_select_sync
-
+def select_flipped(self):
 	bpy.ops.uv.select_all(action='DESELECT')
-	faces = [f for f in bm.faces]
+	sync = bpy.context.scene.tool_settings.use_uv_select_sync
+	premode = bpy.context.scene.tool_settings.uv_select_mode
 
-	flipped_faces = []
-	for f in faces:
-		area = 0.0
-		uvs = [l[uv_layers].uv for l in f.loops]
-		for i in range(len(uvs)):
-			uv1 = uvs[i - 1]
-			uv2 = uvs[i]
-			a = uv1.x * uv2.y - uv1.y * uv2.x
-			area = area + a
-		if area < 0:
-			# clock-wise
-			flipped_faces.append(f)
+	if not sync and premode == 'VERTEX':
+		bpy.ops.uv.select_mode(type='FACE')
 
-	for f in flipped_faces:
-		if sync:
-			f.select_set(True)
-		else:
-			for l in f.loops:
-				l[uv_layers].select = True
+	selected_objs = utilities_uv.selected_unique_objects_in_mode_with_uv()
+	counter = 0
+	for obj in selected_objs:
+		bm = bmesh.from_edit_mesh(obj.data)
+		uv_layer = bm.loops.layers.uv.verify()
+		for f in bm.faces:
+			area = 0.0
+			uvs = [l[uv_layer].uv for l in f.loops]
+			for i in range(len(uvs)):
+				area += uvs[i - 1].cross(uvs[i])
+			if area < 0:
+				counter += 1
+				if sync:
+					f.select_set(True)
+				else:
+					for l in f.loops:
+						l[uv_layer].select = True
+
+	if not counter:
+		self.report({'INFO'}, 'Flipped faces not found')
+		bpy.ops.uv.select_mode(type=premode)
+		return {'CANCELLED'}
 
 	# Workaround to flush the selected UVs from loops to faces
 	if not sync:
 		bpy.ops.uv.select_mode(type='VERTEX')
-		bpy.ops.uv.select_mode(type='FACE')
+		sel_mode = 'FACE' if premode == 'ISLAND' else premode
+		bpy.ops.uv.select_mode(type=sel_mode)
+
+	self.report({'WARNING'}, f'Find {counter} flipped faces')
+	return {'FINISHED'}
+
+
 
 
 bpy.utils.register_class(op)


### PR DESCRIPTION
- Speedup x4
- Using the cross function without its own implementation (performance boost)
- Unnecessary lists (faces and flipped faces) removed (performance boost)
- Now it gives information about the number of flipped faces or their missing.
- Removed multi_loop (performance boost)
- Fixed the moment when flipped faces were highlighted in vertex mode and sync disabled (it reproduced on cube).
- Now select mode does not change (except island mode). 