### PR TITLE
Refactor Unwrap

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1037,10 +1037,10 @@ class UI_PT_Panel_Layout(Panel):
 		row.operator(op_rectify.op.bl_idname, text="Rectify", icon_value = icon_get("op_rectify"))
 
 		split = col.split(factor=0.75, align=True)
-		split.operator(op_uv_unwrap.op.bl_idname, text="Unwrap", icon_value = icon_get("op_uv_unwrap")).axis="xy"
+		split.operator(op_uv_unwrap.op.bl_idname, text="Unwrap", icon_value = icon_get("op_uv_unwrap")).axis = ''
 		row = split.row(align=True)
-		row.operator(op_uv_unwrap.op.bl_idname, text="U").axis="x"
-		row.operator(op_uv_unwrap.op.bl_idname, text="V").axis="y"
+		row.operator(op_uv_unwrap.op.bl_idname, text="U").axis = "x"
+		row.operator(op_uv_unwrap.op.bl_idname, text="V").axis = "y"
 		
 		if settings.bversion >= 3.2:
 			row = col.row(align=True)

--- a/op_uv_unwrap.py
+++ b/op_uv_unwrap.py
@@ -1,163 +1,207 @@
 import bpy
 import bmesh
-import mathutils
 
 from . import utilities_uv
 from . import utilities_ui
-
-
+from mathutils import Vector
+from .utilities_bbox import BBox
 
 class op(bpy.types.Operator):
-    bl_idname = "uv.textools_uv_unwrap"
-    bl_label = "Unwrap"
-    bl_description = "Unwrap selected UVs"
-    bl_options = {'REGISTER', 'UNDO'}
+	bl_idname = "uv.textools_uv_unwrap"
+	bl_label = "Unwrap"
+	bl_description = "Unwrap selected UVs"
+	bl_options = {'REGISTER', 'UNDO'}
 
-    axis: bpy.props.StringProperty(name="axis", default="xy", options={'HIDDEN'})
+	axis: bpy.props.StringProperty(name="axis", default='', options={'HIDDEN'})
 
-    @classmethod
-    def poll(cls, context):
-        if bpy.context.area.ui_type != 'UV':
-            return False
-        if not bpy.context.active_object:
-            return False
-        if bpy.context.active_object.mode != 'EDIT':
-            return False
-        if bpy.context.active_object.type != 'MESH':
-            return False
-        if not bpy.context.object.data.uv_layers:
-            return False
-        if bpy.context.scene.tool_settings.use_uv_select_sync:
-            return False
-        return True
+	@classmethod
+	def poll(cls, context):
+		if bpy.context.area.ui_type != 'UV':
+			return False
+		if not bpy.context.active_object:
+			return False
+		if bpy.context.active_object.mode != 'EDIT':
+			return False
+		if bpy.context.active_object.type != 'MESH':
+			return False
+		if not bpy.context.object.data.uv_layers:
+			return False
+		if bpy.context.scene.tool_settings.use_uv_select_sync:
+			return False
+		return True
 
-
-    def execute(self, context):
-        utilities_uv.multi_object_loop(main, context, self.axis)
-        return {'FINISHED'}
-
+	def execute(self, context):
+		main(self, self.axis)
+		return {'FINISHED'}
 
 
-def main(context, axis):
-    bm = bmesh.from_edit_mesh(bpy.context.active_object.data)
-    uv_layer = bm.loops.layers.uv.verify()
+def main(self, axis):
+	groups = []
+	selected_obj = utilities_uv.selected_unique_objects_in_mode_with_uv()
+	for obj in selected_obj:
+		bm = bmesh.from_edit_mesh(obj.data)
+		uv_layer = bm.loops.layers.uv.verify()
+		# selection_store
+		sel_states = [(loop[uv_layer].select, loop[uv_layer].select_edge) for face in bm.faces for loop in face.loops]
 
-    selected_faces = utilities_uv.selection_store(return_selected_UV_faces=True)
+		# analyze if a full uv-island has been selected.
+		full_islands = []
+		for island in utilities_uv.get_selected_islands(bm, uv_layer, selected=False, extend_selection_to_islands=True):
+			if all(loop[uv_layer].select for face in island for loop in face.loops):
+				full_islands.append(list(island))
 
-    # analyze if a full uv-island has been selected
-    full_islands = utilities_uv.getSelectionIslands(bm, uv_layer, extend_selection_to_islands=True, selected_faces=selected_faces)
-    islands = utilities_uv.getSelectionIslands(bm, uv_layer, extend_selection_to_islands=False, selected_faces=selected_faces, need_faces_selected=False)
+		# store pins and edge seams
+		edge_seam = []
+		for edge in bm.edges:
+			edge_seam.append(edge.seam)
+			edge.seam = False
 
-    selected_uv_islands = []
-    for island in islands:
-        for full_island in full_islands:
-            if island == full_island:
-                selected_uv_islands.append(list(island))
+		# Pin the inverse of the current selection, and cache the uv coords
+		pin_state = []
+		uv_coords = []
+		for face in bm.faces:
+			for loop in face.loops:
+				uv = loop[uv_layer]
+				pin_state.append(uv.pin_uv)
+				uv.pin_uv = not uv.select
+				if axis:
+					uv_coords.append(uv.uv.copy())
 
-    utilities_uv.selection_restore()
+		# If entire islands are selected, pin one vert to keep the island somewhat in place,
+		# otherwise it can get moved away quite randomly by the uv unwrap method; also store some uvs data to reconstruct orientation
+		orient_uvs = []
+		if full_islands:
+			for island in full_islands:
 
-    # store pins and edge seams
-    edge_seam = []
-    for edge in bm.edges:
-        edge_seam.append(edge.seam)
-        edge.seam = False
+				x_min = x_max = y_min = y_max = island[0].loops[0][uv_layer]
+				x_min.pin_uv = True
 
-    # Pin the inverse of the current selection, and cache the uv coords
-    pin_state = []
-    uv_coords = []
-    for face in bm.faces:
-        for loop in face.loops:
-            uv = loop[uv_layer]
-            pin_state.append(uv.pin_uv)
-            uv.pin_uv = not uv.select
+				for face in island:
+					for loop in face.loops:
+						uv = loop[uv_layer]
+						if uv.uv.x > x_max.uv.x:
+							x_max = uv
+						if uv.uv.x < x_min.uv.x:
+							x_min = uv
+						if uv.uv.y > y_max.uv.y:
+							y_max = uv
+						if uv.uv.y < y_min.uv.y:
+							y_min = uv
 
-            uv_coords.append(uv.uv.copy())
+				orient_uvs.append((x_min, x_max, y_min, y_max, x_min.uv.copy(), x_max.uv.copy(), y_min.uv.copy(), y_max.uv.copy()))
 
-    # If entire islands are selected, pin one vert to keep the island somewhat in place, 
-    # otherwise it can get moved away quite randomly by the uv unwrap method; also store some uvs data to reconstruct orientation
-    orient_uvs = []
-    if selected_uv_islands:
-        for island in selected_uv_islands:
+		groups.append((bm, uv_layer, sel_states, full_islands, edge_seam, pin_state, uv_coords, orient_uvs))
 
-            x_min = x_max = y_min = y_max = island[0].loops[0][uv_layer]
-            x_min.pin_uv = True
+	# apply unwrap
+	bpy.ops.uv.select_all(action='SELECT')
+	bpy.ops.uv.seams_from_islands()
 
-            for face in island:
-                for loop in face.loops:
-                    uv = loop[uv_layer]
-                    if uv.uv.x > x_max.uv.x:
-                        x_max = uv
-                    if uv.uv.x < x_min.uv.x:
-                        x_min = uv
-                    if uv.uv.y > y_max.uv.y:
-                        y_max = uv
-                    if uv.uv.y < y_min.uv.y:
-                        y_min = uv
-            
-            orient_uvs.append((x_min, x_max, y_min, y_max, x_min.uv.copy(), x_max.uv.copy(), y_min.uv.copy(), y_max.uv.copy()))
+	padding = utilities_ui.get_padding()
+	bpy.ops.uv.unwrap(method='ANGLE_BASED', margin=padding)
 
-    # apply unwrap
-    bpy.ops.uv.select_all(action='SELECT')
-    bpy.ops.uv.seams_from_islands()
+	# try to reconstruct the original orientation of the uv island
+	up = Vector((0, 1.0))
+	for bm, uv_layer, sel_states, full_islands, edge_seam, pin_state, uv_coords, orient_uvs in groups:
+		for bbox, island in zip(orient_uvs, full_islands):
+			x_min, x_max, y_min, y_max, x_min_coord, x_max_coord, y_min_coord, y_max_coord = bbox
+			prev_bbox = BBox(x_min_coord.x, x_max_coord.x, y_min_coord.y, y_max_coord.y)
 
-    padding = utilities_ui.get_padding()
-    bpy.ops.uv.unwrap(method='ANGLE_BASED', margin=padding)
+			island_bbox = BBox.calc_bbox_uv(island, uv_layer)
+			pivot = island_bbox.center
 
-    # try to reconstruct the original orientation of the uvisland
-    up = mathutils.Vector((0, 1.0))
-    for index, island in enumerate(selected_uv_islands):
-        island_bbox = utilities_uv.get_BBOX(island, bm, uv_layer)
+			# Case: Normal
+			if prev_bbox.max_lenght > 0.0002 and prev_bbox.min_lenght > 2e-08:  # Zero area island protection
+				intial_x_axis = x_min_coord - x_max_coord
+				intial_x_angle = up.angle_signed(intial_x_axis)
 
-        x_min, x_max, y_min, y_max, x_min_coord, x_max_coord, y_min_coord, y_max_coord = orient_uvs[index]
-    
-        intial_x_axis = x_min_coord - x_max_coord       
-        intial_x_angle = up.angle_signed(intial_x_axis)
+				axis_x_current = x_min.uv - x_max.uv
+				current_x_angle = up.angle_signed(axis_x_current)
 
-        axis_x_current = x_min.uv - x_max.uv
-        current_x_angle = up.angle_signed(axis_x_current)
+				intial_y_axis = y_min_coord - y_max_coord
+				intial_y_angle = up.angle_signed(intial_y_axis)
 
-        intial_y_axis = y_min_coord - y_max_coord       
-        intial_y_angle = up.angle_signed(intial_y_axis)
+				axis_y_current = y_min.uv - y_max.uv
+				current_y_angle = up.angle_signed(axis_y_current)
 
-        axis_y_current = y_min.uv - y_max.uv
-        current_y_angle = up.angle_signed(axis_y_current)
+				angle_x = intial_x_angle - current_x_angle
+				angle_y = intial_y_angle - current_y_angle
+				angle = min(angle_x, angle_y)
 
-        angle_x = intial_x_angle - current_x_angle
-        angle_y = intial_y_angle - current_y_angle
-        angle = min(angle_x, angle_y)
+				utilities_uv.rotate_island(island, uv_layer, angle, pivot)
 
-        center = island_bbox['center']
-        utilities_uv.rotate_island(island, uv_layer, angle, center)
+				# keep it the same size
+				scale_x = intial_x_axis.length / axis_x_current.length
+				scale_y = intial_y_axis.length / axis_y_current.length
+				scale = min([scale_x, scale_y], key=lambda x: abs(x-1.0))  # pick scale closer to 1.0
 
-        #keep it the same size
-        scale_x = intial_x_axis.length / axis_x_current.length 
-        scale_y = intial_y_axis.length / axis_y_current.length 
-        scale  = min([scale_x, scale_y], key=lambda x:abs(x-1.0)) #pick scale closer to 1.0
-        utilities_uv.scale_island(island, uv_layer, scale, scale, center)
+				utilities_uv.scale_island(island, uv_layer, Vector((scale, scale)), pivot)
+			# case: when the island had zero area, but was stretched on the axis
+			elif prev_bbox.max_lenght > 0.0001 and prev_bbox.min_lenght < 2e-09:
+				scale = prev_bbox.max_lenght / island_bbox.max_lenght
+				utilities_uv.scale_island(island, uv_layer, Vector((scale, scale)), pivot)
+				self.report({'INFO'}, f'A stretched island with zero area has been found, and successfully deployed')
+			# case: when area zero
+			elif island_bbox.area > 0.2:
+				scale = 0.2/island_bbox.max_lenght
+				utilities_uv.scale_island(island, uv_layer, Vector((scale, scale)), pivot)
+				self.report({'WARNING'}, f'UV Island with zero area was detected and scaled to 0.2.')
+			# case: when island small
+			elif island_bbox.area < 1e-05:
+				length = prev_bbox.max_lenght
+				if prev_bbox.max_lenght == 0:
+					length = island_bbox.max_lenght
+				sum_length = 0
+				count_valid_bbox = 0
+				# Finding the average size of other islands, and scaling to their size
+				for orient_uv in orient_uvs:
+					x_min, x_max, y_min, y_max = orient_uv[:4]
+					all_bbox = BBox(x_min.uv.x, x_max.uv.x, y_min.uv.y, y_max.uv.y)
+					max_length = all_bbox.max_lenght
+					if max_length > 1e-05:
+						sum_length += max_length
+						count_valid_bbox += 1
+				if count_valid_bbox:
+					avg_length = sum_length / count_valid_bbox
+					scale = avg_length / length
+					self.report(
+						{'WARNING'}, f"UV Island with a small area ({island_bbox.area}) was found and scaled "
+						f"to the average size ({scale}) of the other islands. To validate the unwrap, try again.")
+				else:
+					scale = 0.2 / length
+					self.report({'WARNING'}, f'UV Island with small area ({island_bbox.area}) was detected and scaled to 0.2')
+				utilities_uv.scale_island(island, uv_layer, Vector((scale, scale)), pivot)
+			else:
+				self.report({'WARNING'}, f'Island not have boundary edges or other')
 
-        #move back into place
-        delta = x_min_coord - x_min.uv
-        utilities_uv.move_island(island, delta.x, delta.y)
+			# move back into place
+			delta = x_min_coord - x_min.uv
+			utilities_uv.translate_island(island, uv_layer, delta)
 
-    # restore selections, pins & edge seams
-    index = 0
-    for face in bm.faces:
-        for loop in face.loops:
-            uv = loop[uv_layer]
-            uv.pin_uv = pin_state[index]
+		# restore selections, pins & edge seams
+		index = 0
+		for face in bm.faces:
+			for loop in face.loops:
+				uv = loop[uv_layer]
+				uv.pin_uv = pin_state[index]
 
-            #apply axis constraint
-            if axis == "x":
-                uv.uv.y = uv_coords[index].y
-            elif axis == "y":
-                uv.uv.x = uv_coords[index].x
+				# apply axis constraint
+				if axis:
+					if axis == "x":
+						uv.uv.y = uv_coords[index].y
+					else:
+						uv.uv.x = uv_coords[index].x
+				index += 1
 
-            index += 1
+		for edge, seam in zip(bm.edges, edge_seam):
+			edge.seam = seam
 
-    for index, edge in enumerate(bm.edges):
-        edge.seam = edge_seam[index]
+		# restore selection
+		luvs = (loop[uv_layer] for face in bm.faces for loop in face.loops)
+		for luv, sel_state in zip(luvs, sel_states):
+			luv.select, luv.select_edge = sel_state
 
-    utilities_uv.selection_restore()
+	for obj in selected_obj:
+		bmesh.update_edit_mesh(obj.data)
 
 
 bpy.utils.register_class(op)

--- a/utilities_uv.py
+++ b/utilities_uv.py
@@ -306,22 +306,11 @@ def rotate_island(island, uv_layer=None, angle=0, pivot=None):
 			uv.uv = uv.uv @ rot_matrix
 
 
-def scale_island(island, uv_layer, scale_x, scale_y, pivot=None):
+def scale_island(island, uv_layer, scale, pivot):
 	"""Scale a list of faces by 'scale_x, scale_y'. """
-
-	if not pivot:
-		bbox = get_BBOX(island, None, uv_layer)
-		pivot = bbox['center']
-	
 	for face in island:
 		for loop in face.loops:
-			x, y = loop[uv_layer].uv               
-			xt = x - pivot.x
-			yt = y - pivot.y
-			xs = xt * scale_x
-			ys = yt * scale_y
-			loop[uv_layer].uv.x = xs + pivot.x
-			loop[uv_layer].uv.y = ys + pivot.y
+			loop[uv_layer].uv = (loop[uv_layer].uv - pivot) * scale + pivot
 
 
 def set_selected_faces(faces, bm, uv_layers):


### PR DESCRIPTION
Speedup: 
-100 separate monkeys old 4.48 new 3.22 (x1.4)
-100 union monkeys old 29 new 3 (x1.4) (x9.6)

- Removed multi_obj_loop
- Handled full_selection_islands more efficiently, now islands are calculated only once.
- selection_store is replaced by more efficient calculation, without unnecessary calculations.
- Added processing of islands with zero area
- Added processing of islands with zero area but stretched out
- Islands too small, reset size to 0.1
- Too big islands (which were zero islands before) resize to 0.2.
- All the above processing prevents ZeroDivision error and gives more information about the problem.
- Reduced the code size of the scale_island function, now less python objects are created (spedup more x2).