### PR TITLE
Refactor Randomize

### DIFF
--- a/op_randomize.py
+++ b/op_randomize.py
@@ -1,169 +1,135 @@
-import bpy
-import bmesh
 import math
 import random
-import numpy as np
+import bpy
+import bmesh
+import bl_math
 
-from mathutils import Vector
 from . import utilities_uv
-
+from .utilities_bbox import BBox
+from mathutils import Vector
 
 
 class op(bpy.types.Operator):
 	bl_idname = "uv.textools_randomize"
 	bl_label = "Randomize Position"
-	bl_description = "Randomize selected UV faces position and/or rotation"
+	bl_description = "Randomize selected UV faces position and/or rotation and/or scale"
 	bl_options = {'REGISTER', 'UNDO'}
 	
-	bool_face : bpy.props.BoolProperty(name="Per Face", default=False)
-	intmode : bpy.props.BoolProperty(name="Int mode", default=False)
-	strengh_U : bpy.props.FloatProperty(name="U Strengh", default=1, min=-10, max=10, soft_min=0, soft_max=1)
-	strengh_V : bpy.props.FloatProperty(name="V Strengh", default=1, min=-10, max=10, soft_min=0, soft_max=1)
-	rotation : bpy.props.FloatProperty(name="Rotation Strengh", default=0, min=-10, max=10, soft_min=0, soft_max=1)
-	bool_precenter : bpy.props.BoolProperty(name="Pre Center Faces/Islands", default=False, description="Collect all faces/islands around the center of the UV space.")
-	bool_bounds : bpy.props.BoolProperty(name="Within Image Bounds", default=False, description="Keep the UV faces/islands within the 0-1 UV domain.")
-	rand_seed : bpy.props.IntProperty(name="Seed", default=0)
+	bool_face: bpy.props.BoolProperty(name="Per Face", default=False)
+	intmode: bpy.props.BoolProperty(name="Int mode", default=False)
+	strength_U: bpy.props.FloatProperty(name="U Strength", default=1, min=-10, max=10, soft_min=0, soft_max=1)
+	strength_V: bpy.props.FloatProperty(name="V Strength", default=1, min=-10, max=10, soft_min=0, soft_max=1)
+	rotation: bpy.props.FloatProperty(name="Rotation Strength", default=0, min=-10, max=10, soft_min=0, soft_max=1)
+	scale: bpy.props.FloatProperty(name="Scale Strength", default=1, min=0.0, max=10, soft_max=2)
+	bool_precenter: bpy.props.BoolProperty(
+		name="Pre Center Faces/Islands", default=False, description="Collect all faces/islands around the center of the UV space.")
+	bool_bounds: bpy.props.BoolProperty(
+		name="Within Image Bounds", default=False, description="Keep the UV faces/islands within the 0-1 UV domain.")
+	rand_seed: bpy.props.IntProperty(name="Seed", default=0)
 
 	@classmethod
 	def poll(cls, context):
-		if bpy.context.area.ui_type != 'UV':
-			return False
 		if not bpy.context.active_object:
 			return False
 		if bpy.context.active_object.type != 'MESH':
 			return False
 		if bpy.context.active_object.mode != 'EDIT':
 			return False
-		if not bpy.context.object.data.uv_layers:
-			return False
 		return True
 
-
 	def execute(self, context):
+		udim_tile = 1001
+		column = row = 0
 		if self.bool_bounds or self.bool_precenter:
 			udim_tile, column, row = utilities_uv.get_UDIM_tile_coords(bpy.context.active_object)
-		else:
-			udim_tile = 1001
-			column = row = 0
-		utilities_uv.multi_object_loop(main, self, context, udim_tile=udim_tile, column=column, row=row, ob_num=0)
-		return {'FINISHED'}
+
+		return main(self, context, udim_tile=udim_tile, column=column, row=row)
 
 	def invoke(self, context, event):
 		wm = context.window_manager
 		return wm.invoke_props_dialog(self)
 
 
+def main(self, context, udim_tile=1001, column=0, row=0):
+	counter = 0
+	selected_obj = utilities_uv.selected_unique_objects_in_mode_with_uv()
+	for e1, obj in enumerate(selected_obj, start=2):
+		me = obj.data
+		bm = bmesh.from_edit_mesh(me)
+		uv_layers = bm.loops.layers.uv.verify()
+		sync = bpy.context.scene.tool_settings.use_uv_select_sync
 
-def main(self, context, udim_tile=1001, column=0, row=0, ob_num=0):
-	selection_mode = bpy.context.scene.tool_settings.uv_select_mode
-	me = bpy.context.active_object.data
-	bm = bmesh.from_edit_mesh(me)
-	uv_layers = bm.loops.layers.uv.verify()
-	sync = bpy.context.scene.tool_settings.use_uv_select_sync
-
-	if sync:
-		pregroup = {f for f in bm.faces if f.select}
-	else:
-		pregroup = {f for f in bm.faces if all([l[uv_layers].select for l in f.loops]) and f.select}
-	if not pregroup:
-		return
-
-	random.seed(self.rand_seed + ob_num)
-
-	if not self.bool_face:
-		group = utilities_uv.get_selected_islands(bm, uv_layers)
-	else:
-		group = pregroup
-
-
-	for f in group:
-		rand_v = Vector(( 2*(random.random()-0.5), 2*(random.random()-0.5) ))
-		rand_3 = 2*(random.random()-0.5)
-
-
-		if self.bool_bounds or self.bool_precenter or self.rotation:
-			if self.rotation:
-				theta = self.rotation*rand_3*math.pi
-				matrix = np.array([[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]])
+		if self.bool_face:
+			if sync:
+				group = {f for f in bm.faces if f.select}
 			else:
-				matrix = np.array([[1, 0], [0, 1]])
-			
-			if not self.bool_face:
+				group = utilities_uv.get_selected_uv_faces(bm, uv_layers)
+		else:
+			group = utilities_uv.get_selected_islands(bm, uv_layers)
+
+		if not group:
+			continue
+
+		counter += 1
+		for e2, f in enumerate(group, start=2):
+			seed = e1*e2+(self.rand_seed+200)+id(obj)
+			random.seed(seed)
+			rand_rotation = 2*(random.random()-0.5)
+			random.seed(seed+2)
+			rand_scale = random.random()-0.5
+
+			f = (f,) if self.bool_face else f
+
+			if self.bool_bounds or self.bool_precenter or self.rotation or self.scale != 1:
+
 				vec_origin = utilities_uv.get_center(f, bm, uv_layers)
+
 				if self.bool_bounds or self.bool_precenter:
-					for i in f:
-						for loop in i.loops:
-							uvs0 = loop[uv_layers].uv - vec_origin
-							loop[uv_layers].uv = (0.5 + matrix[0][0]*uvs0.x + matrix[0][1]*uvs0.y, 0.5 + matrix[1][0]*uvs0.x + matrix[1][1]*uvs0.y)
-				else:
-					for i in f:
-						for loop in i.loops:
-							uvs0 = loop[uv_layers].uv - vec_origin
-							loop[uv_layers].uv = (vec_origin.x + matrix[0][0]*uvs0.x + matrix[0][1]*uvs0.y, vec_origin.y + matrix[1][0]*uvs0.x + matrix[1][1]*uvs0.y)
+					utilities_uv.translate_island(f, uv_layers, delta=Vector((0.5, 0.5)) - vec_origin)
+
+				if self.rotation:
+					angle = self.rotation * rand_rotation * math.pi
+					utilities_uv.rotate_island(f, uv_layers, angle, vec_origin)
+
+				if self.scale != 1:
+					scale = bl_math.lerp(rand_scale, 1.0, self.scale)
+					scale = bl_math.clamp(scale, 0.01, 10.0)
+					utilities_uv.scale_island(f, uv_layers, Vector((scale, scale)), pivot=vec_origin)
+
+			if self.bool_bounds:
+				bb = BBox.calc_bbox_uv(f, uv_layers)
+				move = Vector((
+					min(bb.xmin, abs(1 - bb.xmax)) * max(min(self.strength_U, 1), -1),
+					min(bb.ymin, abs(1 - bb.ymax)) * max(min(self.strength_V, 1), -1)
+				))
 			else:
-				vec_origin = utilities_uv.get_center(f.loops, bm, uv_layers, are_loops=True)
-				if self.bool_bounds or self.bool_precenter:
-					for loop in f.loops:
-						uvs0 = loop[uv_layers].uv - vec_origin
-						loop[uv_layers].uv = (0.5 + matrix[0][0]*uvs0.x + matrix[0][1]*uvs0.y, 0.5 + matrix[1][0]*uvs0.x + matrix[1][1]*uvs0.y)
-				else:
-					for loop in f.loops:
-						uvs0 = loop[uv_layers].uv - vec_origin
-						loop[uv_layers].uv = (vec_origin.x + matrix[0][0]*uvs0.x + matrix[0][1]*uvs0.y, vec_origin.y + matrix[1][0]*uvs0.x + matrix[1][1]*uvs0.y)
-			
-			bmesh.update_edit_mesh(me, loop_triangles=False)
+				move = Vector((self.strength_U, self.strength_V))
 
+			if not (move.x or move.y):
+				continue
 
-		if self.bool_bounds:
-			boundsMin = Vector((math.inf, math.inf))
-			boundsMax = Vector((-math.inf, -math.inf))
+			random.seed(seed+3)
+			rand_move_x = 2*(random.random()-0.5)
+			random.seed(seed+4)
+			rand_move_y = 2*(random.random()-0.5)
 
-			if not self.bool_face:
-				for i in f:
-					for loop in i.loops:
-						uv = loop[uv_layers].uv
-						boundsMin = Vector(( max( min(boundsMin.x, uv.x), 0 ), max( min(boundsMin.y, uv.y), 0 ) ))
-						boundsMax = Vector(( min( max(boundsMax.x, uv.x), 1 ), min( max(boundsMax.y, uv.y), 1 ) ))
+			randmove = Vector((rand_move_x, rand_move_y)) * move
+
+			if self.intmode:
+				randmove = Vector(round(i) for i in randmove)
+
+			if (not self.bool_bounds and not self.bool_precenter) or udim_tile == 1001:
+				utilities_uv.translate_island(f, uv_layers, randmove)
 			else:
-				for loop in f.loops:
-					uv = loop[uv_layers].uv
-					boundsMin = Vector(( max( min(boundsMin.x, uv.x), 0 ), max( min(boundsMin.y, uv.y), 0 ) ))
-					boundsMax = Vector(( min( max(boundsMax.x, uv.x), 1 ), min( max(boundsMax.y, uv.y), 1 ) ))
-			
-			move = Vector(( min(boundsMin.x, abs(1-boundsMax.x)) * max( min(self.strengh_U, 1), -1 ),  min(boundsMin.y, abs(1-boundsMax.y)) * max( min(self.strengh_V, 1), -1 ) ))
-		else:
-			move = Vector((self.strengh_U, self.strengh_V))
+				utilities_uv.translate_island(f, uv_layers, delta=randmove + Vector((column, row)))
 
+		bmesh.update_edit_mesh(me, loop_triangles=False, destructive=False)
 
-		randmove = rand_v * move
-		if self.intmode:
-			randmove = Vector(np.around(randmove))
+	if counter:
+		return {'FINISHED'}
 
-		if (not self.bool_bounds and not self.bool_precenter) or udim_tile == 1001:
-			if move.x or move.y:
-				if not self.bool_face:
-					for i in f:
-						for loop in i.loops:
-							loop[uv_layers].uv += randmove
-				else:
-					for loop in f.loops:
-						loop[uv_layers].uv += randmove
-		else:
-			if move.x or move.y:
-				if not self.bool_face:
-					for i in f:
-						for loop in i.loops:
-							loop[uv_layers].uv += randmove + Vector((column, row))
-				else:
-					for loop in f.loops:
-						loop[uv_layers].uv += randmove + Vector((column, row))
-
-	bmesh.update_edit_mesh(me, loop_triangles=False)
-
-	# Workaround for selection not flushing properly from loops to EDGE Selection Mode, apparently since UV edge selection support was added to the UV space
-	if not sync:
-		bpy.ops.uv.select_mode(type='VERTEX')
-		bpy.context.scene.tool_settings.uv_select_mode = selection_mode
+	self.report({'WARNING'}, "No object for randomize.")
+	return {'CANCELLED'}
 
 
 bpy.utils.register_class(op)

--- a/op_randomize.py
+++ b/op_randomize.py
@@ -36,8 +36,7 @@ class op(bpy.types.Operator):
 		update=lambda self, _: setattr(self, 'min_scale', self.max_scale) if self.max_scale < self.min_scale else None)
 	bool_precenter: bpy.props.BoolProperty(
 		name="Pre Center Faces/Islands", default=False, description="Collect all faces/islands around the center of the UV space.")
-	bool_bounds: bpy.props.BoolProperty(
-		name="Within Image Bounds", default=False, description="Keep the UV faces/islands within the 0-1 UV domain.")
+	bool_bounds: bpy.props.BoolProperty(name="Within Image Bounds", default=False, description="Keep the UV faces/islands within the 0-1 UV domain.",)
 	rand_seed: bpy.props.IntProperty(name="Seed", default=0)
 
 	@classmethod
@@ -52,6 +51,9 @@ class op(bpy.types.Operator):
 
 	def draw(self, context):
 		layout = self.layout
+		if self.bool_precenter and 0 in self.strength:
+			layout.label(text='Zero strength with enabled Pre Center', icon='ERROR')
+
 		for prop in self.__annotations__:
 			if prop == 'steps' and self.round_mode != 'STEPS':
 				continue

--- a/op_randomize.py
+++ b/op_randomize.py
@@ -16,7 +16,8 @@ class op(bpy.types.Operator):
 	bl_options = {'REGISTER', 'UNDO'}
 	
 	bool_face: bpy.props.BoolProperty(name="Per Face", default=False)
-	intmode: bpy.props.BoolProperty(name="Int mode", default=False)
+	steps_U: bpy.props.FloatProperty(name="U Steps (Incorrectly works with Within Image Bounds)", default=0, min=0, max=10, soft_min=0, soft_max=1)
+	steps_V: bpy.props.FloatProperty(name="V Steps (Incorrectly works with Within Image Bounds)", default=0, min=0, max=10, soft_min=0, soft_max=1)
 	strength_U: bpy.props.FloatProperty(name="U Strength", default=1, min=-10, max=10, soft_min=0, soft_max=1)
 	strength_V: bpy.props.FloatProperty(name="V Strength", default=1, min=-10, max=10, soft_min=0, soft_max=1)
 	rotation: bpy.props.FloatProperty(name="Rotation Strength", default=0, min=-10, max=10, soft_min=0, soft_max=1)
@@ -53,7 +54,7 @@ class op(bpy.types.Operator):
 def main(self, context, udim_tile=1001, column=0, row=0):
 	counter = 0
 	selected_obj = utilities_uv.selected_unique_objects_in_mode_with_uv()
-	for e1, obj in enumerate(selected_obj, start=2):
+	for e1, obj in enumerate(selected_obj, start=100):
 		me = obj.data
 		bm = bmesh.from_edit_mesh(me)
 		uv_layers = bm.loops.layers.uv.verify()
@@ -71,8 +72,9 @@ def main(self, context, udim_tile=1001, column=0, row=0):
 			continue
 
 		counter += 1
-		for e2, f in enumerate(group, start=2):
-			seed = e1*e2+(self.rand_seed+200)+id(obj)
+		bb_general = BBox()
+		for e2, f in enumerate(group, start=100):
+			seed = e1*e2+self.rand_seed+id(obj)
 			random.seed(seed)
 			rand_rotation = 2*(random.random()-0.5)
 			random.seed(seed+2)
@@ -81,26 +83,50 @@ def main(self, context, udim_tile=1001, column=0, row=0):
 			f = (f,) if self.bool_face else f
 
 			if self.bool_bounds or self.bool_precenter or self.rotation or self.scale != 1:
+				bb = BBox.calc_bbox_uv(f, uv_layers)
+				if not bb.is_valid:
+					self.report({'WARNING'}, f"The {obj.name} object have UV-Island with zero area")
+					continue
 
-				vec_origin = utilities_uv.get_center(f, bm, uv_layers)
-
-				if self.bool_bounds or self.bool_precenter:
-					utilities_uv.translate_island(f, uv_layers, delta=Vector((0.5, 0.5)) - vec_origin)
+				vec_origin = bb.center
 
 				if self.rotation:
 					angle = self.rotation * rand_rotation * math.pi
-					utilities_uv.rotate_island(f, uv_layers, angle, vec_origin)
+					if utilities_uv.rotate_island(f, uv_layers, angle, vec_origin):
+						bb.rotate_expand(angle)
 
-				if self.scale != 1:
-					scale = bl_math.lerp(rand_scale, 1.0, self.scale)
-					scale = bl_math.clamp(scale, 0.01, 10.0)
-					utilities_uv.scale_island(f, uv_layers, Vector((scale, scale)), pivot=vec_origin)
+				scale = bl_math.lerp(rand_scale, 1.0, self.scale)
+				scale = bl_math.clamp(scale, 0.01, 10.0)
+
+				new_scale = 100
+				# Reset the scale to 0.5 to fit in the tile.
+				if self.bool_bounds or self.bool_precenter:
+					max_length = bb.max_lenght
+					max_length_lock = 1.0
+					if self.bool_precenter:
+						min_stretch = min(abs(self.strength_U), abs(self.strength_V))
+						max_length_lock = max(min(1.0, min_stretch), 1e-09)
+
+					if max_length * scale > max_length_lock:
+						new_scale = max_length_lock / max_length
+
+				if self.scale != 1 or new_scale < 1:
+					# If the scale from random is smaller, we choose it
+					scale = min(scale, new_scale)
+					scale = Vector((scale, scale))
+					utilities_uv.scale_island(f, uv_layers, scale, pivot=vec_origin)
+					bb.scale(scale)
+
+				if self.bool_bounds or self.bool_precenter:
+					to_center_delta = Vector((0.5, 0.5)) - vec_origin
+					utilities_uv.translate_island(f, uv_layers, delta=to_center_delta)
+					bb.translate(to_center_delta)
+					bb_general.union(bb)
 
 			if self.bool_bounds:
-				bb = BBox.calc_bbox_uv(f, uv_layers)
 				move = Vector((
-					min(bb.xmin, abs(1 - bb.xmax)) * max(min(self.strength_U, 1), -1),
-					min(bb.ymin, abs(1 - bb.ymax)) * max(min(self.strength_V, 1), -1)
+					min(bb_general.xmin, abs(1 - bb_general.xmax)) * max(min(self.strength_U, 1), -1),
+					min(bb_general.ymin, abs(1 - bb_general.ymax)) * max(min(self.strength_V, 1), -1)
 				))
 			else:
 				move = Vector((self.strength_U, self.strength_V))
@@ -114,9 +140,14 @@ def main(self, context, udim_tile=1001, column=0, row=0):
 			rand_move_y = 2*(random.random()-0.5)
 
 			randmove = Vector((rand_move_x, rand_move_y)) * move
+			# ToDo bool_bounds for steps
+			if self.steps_U > 1e-05:
+				randmove.x = round_threshold(randmove.x, self.steps_U)
+			if self.steps_V > 1e-05:
+				randmove.y = round_threshold(randmove.y, self.steps_V)
 
-			if self.intmode:
-				randmove = Vector(round(i) for i in randmove)
+			# if self.bool_bounds:
+			# 	pass
 
 			if (not self.bool_bounds and not self.bool_precenter) or udim_tile == 1001:
 				utilities_uv.translate_island(f, uv_layers, randmove)
@@ -130,6 +161,9 @@ def main(self, context, udim_tile=1001, column=0, row=0):
 
 	self.report({'WARNING'}, "No object for randomize.")
 	return {'CANCELLED'}
+
+def round_threshold(a, min_clip):
+	return round(float(a) / min_clip) * min_clip
 
 
 bpy.utils.register_class(op)

--- a/op_randomize.py
+++ b/op_randomize.py
@@ -11,8 +11,8 @@ from mathutils import Vector
 
 class op(bpy.types.Operator):
 	bl_idname = "uv.textools_randomize"
-	bl_label = "Randomize Position"
-	bl_description = "Randomize selected UV faces position and/or rotation and/or scale"
+	bl_label = "Randomize"
+	bl_description = "Randomize selected UV islands or faces"
 	bl_options = {'REGISTER', 'UNDO'}
 	
 	bool_face: bpy.props.BoolProperty(name="Per Face", default=False)

--- a/op_texel_density_set.py
+++ b/op_texel_density_set.py
@@ -62,10 +62,7 @@ def set_texel_density(self, context, edit_mode, getmode, setmode, density, udim_
 	uv_layers = bm.loops.layers.uv.verify()
 
 	if edit_mode:
-		if is_sync:
-			object_faces = [face for face in bm.faces if face.select]
-		else:
-			object_faces = utilities_uv.get_selected_uv_faces(bm, uv_layers)
+		object_faces = utilities_uv.get_selected_uv_faces(bm, uv_layers)
 	else:
 		object_faces = bm.faces
 
@@ -95,7 +92,6 @@ def set_texel_density(self, context, edit_mode, getmode, setmode, density, udim_
 		size = min(bpy.context.scene.texToolsSettings.size[0], bpy.context.scene.texToolsSettings.size[1])
 	else:
 		size = int(getmode)
-
 
 	if getmode != 'IMAGE' or (image and getmode == 'IMAGE'):
 		if is_sync:
@@ -128,7 +124,7 @@ def set_texel_density(self, context, edit_mode, getmode, setmode, density, udim_
 			for face in group:
 				# Decomposed face into triagles to calculate area
 				tris = len(face.loops)-2
-				if tris <=0:
+				if tris <= 0:
 					continue
 				if setmode == 'ISLAND':
 					for loop in face.loops:
@@ -157,8 +153,8 @@ def set_texel_density(self, context, edit_mode, getmode, setmode, density, udim_
 
 				area_vt += face.calc_area()
 
-				sum_area_uv += math.sqrt( area_uv ) * size
-				sum_area_vt += math.sqrt( area_vt )
+				sum_area_uv += math.sqrt(area_uv) * size
+				sum_area_vt += math.sqrt(area_vt)
 
 
 			# Apply scale to group

--- a/utilities_bbox.py
+++ b/utilities_bbox.py
@@ -1,5 +1,5 @@
 import math
-from mathutils import Vector
+from mathutils import Vector, Matrix
 
 
 class BBox:
@@ -186,6 +186,38 @@ class BBox:
 			self.xmax = xmax
 		if self.ymax > ymax:
 			self.ymax = ymax
+
+	def translate(self, delta):
+		self.xmin, self.ymin = self.min + delta
+		self.xmax, self.ymax = self.max + delta
+		return self
+
+	def rotate_expand(self, angle):
+		center = self.center
+		rot_matrix = Matrix.Rotation(-angle, 2)
+
+		corner = self.right_upper - center
+		corner_rot = corner @ rot_matrix
+		corner_max = Vector((abs(corner_rot[0]), abs(corner_rot[1])))
+
+		corner.y *= -1
+		corner_rot = corner @ rot_matrix
+		corner_max[0] = max(corner_max[0], abs(corner_rot[0]))
+		corner_max[1] = max(corner_max[1], abs(corner_rot[1]))
+
+		self.xmin = center[0] - corner_max[0]
+		self.xmax = center[0] + corner_max[0]
+		self.ymin = center[1] - corner_max[1]
+		self.ymax = center[1] + corner_max[1]
+
+		return self
+
+	def scale(self, scale):
+		center = self.center
+		self.xmin, self.ymin = (self.min - center) * scale + center
+		self.xmax, self.ymax = (self.max - center) * scale + center
+		return self.sanitize()
+
 
 	def update(self, coords):
 		for x, y in coords:

--- a/utilities_bbox.py
+++ b/utilities_bbox.py
@@ -177,6 +177,16 @@ class BBox:
 		if xy[1] > self.ymax:
 			self.ymax = xy[1]
 
+	def clamp(self, xmin=0, ymin=0, xmax=1, ymax=1):
+		if self.xmin < xmin:
+			self.xmin = xmin
+		if self.ymin < ymin:
+			self.ymin = ymin
+		if self.xmax > xmax:
+			self.xmax = xmax
+		if self.ymax > ymax:
+			self.ymax = ymax
+
 	def update(self, coords):
 		for x, y in coords:
 			if x < self.xmin:

--- a/utilities_uv.py
+++ b/utilities_uv.py
@@ -12,8 +12,7 @@ precision = 5
 multi_object_loop_stop = False
 
 
-
-def multi_object_loop(func, *args, need_results = False, **kwargs) :
+def multi_object_loop(func, *args, need_results=False, **kwargs):
 	selected_obs = [ob for ob in bpy.context.selected_objects if ob.type == 'MESH']
 
 	if len(selected_obs) == 1:
@@ -41,7 +40,7 @@ def multi_object_loop(func, *args, need_results = False, **kwargs) :
 		bpy.ops.object.mode_set(mode='OBJECT', toggle=False)
 		bpy.ops.object.select_all(action='DESELECT')
 
-		if need_results :
+		if need_results:
 			results = []
 
 		for ob in unique_selected_obs:
@@ -49,11 +48,11 @@ def multi_object_loop(func, *args, need_results = False, **kwargs) :
 				break
 			bpy.context.view_layer.objects.active = ob
 			bpy.ops.object.mode_set(mode='EDIT', toggle=False)
-			if "ob_num" in kwargs :
+			if "ob_num" in kwargs:
 				print("Operating on object " + str(kwargs["ob_num"]))
-			if need_results :
+			if need_results:
 				result = func(*args, **kwargs)
-				#if result:
+				# if result:
 				results.append(result)
 			else:
 				func(*args, **kwargs)
@@ -68,9 +67,8 @@ def multi_object_loop(func, *args, need_results = False, **kwargs) :
 		bpy.context.view_layer.objects.active = bpy.data.objects[preactiv_name]
 		bpy.ops.object.mode_set(mode=premode)
 
-		if need_results :
+		if need_results:
 			return results
-
 
 
 def selection_store(bm=None, uv_layers=None, return_selected_UV_faces=False, return_selected_faces_edges=False, return_selected_faces_loops=False):
@@ -118,11 +116,11 @@ def selection_store(bm=None, uv_layers=None, return_selected_UV_faces=False, ret
 			face_selected_loops = []
 		
 		for loop in face.loops:
-			if loop.edge.seam == True:
+			if loop.edge.seam:
 				settings.seam_edges.add(loop.edge)
 			if loop[uv_layers].select:
 				n_selected_loops += 1
-				settings.selection_uv_loops.add( (face.index, loop.vert.index) )
+				settings.selection_uv_loops.add((face.index, loop.vert.index))
 				if return_selected_faces_edges or return_selected_faces_loops:
 					face_selected_loops.append(loop)
 		
@@ -139,11 +137,10 @@ def selection_store(bm=None, uv_layers=None, return_selected_UV_faces=False, ret
 		return selected_faces_loops
 
 
-
-def selection_restore(bm = None, uv_layers = None, restore_seams=False):
+def selection_restore(bm=None, uv_layers=None, restore_seams=False):
 	mode = bpy.context.object.mode
 	if mode != 'EDIT':
-		bpy.ops.object.mode_set(mode = 'EDIT')
+		bpy.ops.object.mode_set(mode='EDIT')
 	if bm is None:
 		bm = bmesh.from_edit_mesh(bpy.context.active_object.data)
 		uv_layers = bm.loops.layers.uv.verify()
@@ -160,7 +157,7 @@ def selection_restore(bm = None, uv_layers = None, restore_seams=False):
 		else:
 			bpy.ops.uv.cursor_set(contextViewUV, location=settings.selection_uv_pivot_pos)
 
-	#Restore seams
+	# Restore seams
 	if restore_seams:
 		bpy.ops.mesh.select_all(action='SELECT')
 		bpy.ops.mesh.mark_seam(clear=True)
@@ -169,7 +166,7 @@ def selection_restore(bm = None, uv_layers = None, restore_seams=False):
 
 	bpy.ops.mesh.select_all(action='DESELECT')
 
-	#Selection Mode
+	# Selection Mode
 	bpy.context.scene.tool_settings.mesh_select_mode = settings.selection_mode
 	
 	if settings.selection_mode[0]:
@@ -187,7 +184,7 @@ def selection_restore(bm = None, uv_layers = None, restore_seams=False):
 		if index < len(bm.faces):
 			bm.faces[index].select = True
 
-	#UV Face-UV Selections (Loops)
+	# UV Face-UV Selections (Loops)
 	if contextViewUV:
 		if settings.bversion >= 3.2:
 			with bpy.context.temp_override(**contextViewUV):
@@ -204,7 +201,8 @@ def selection_restore(bm = None, uv_layers = None, restore_seams=False):
 				loop[uv_layers].select = True
 				break
 
-	# Workaround for selection not flushing properly from loops in EDGE or FACE UV Selection Mode, apparently since UV edge selection support was added to the UV space
+	# Workaround for selection not flushing properly from loops in EDGE or FACE UV Selection Mode,
+	# apparently since UV edge selection support was added to the UV space
 	if settings.selection_uv_mode != "VERTEX":
 		bpy.ops.uv.select_mode(type='VERTEX')
 	bpy.context.scene.tool_settings.uv_select_mode = settings.selection_uv_mode
@@ -215,6 +213,7 @@ def selection_restore(bm = None, uv_layers = None, restore_seams=False):
 
 def selected_unique_objects_in_mode_with_uv():
 	return [obj for obj in bpy.context.objects_in_mode_unique_data if obj.type == 'MESH' and obj.data.uv_layers]
+
 
 def get_UDIM_tile_coords(obj):
 	udim_tile = 1001
@@ -229,7 +228,7 @@ def get_UDIM_tile_coords(obj):
 						nodes = slot.material.node_tree.nodes
 						if nodes:
 							for node in nodes:
-								if node.type == 'TEX_IMAGE' and node.image and node.image.source =='TILED':
+								if (node.type == 'TEX_IMAGE') and node.image and (node.image.source == 'TILED'):
 									udim_tile = node.image.tiles.active.number
 									break
 				else:
@@ -248,7 +247,6 @@ def get_UDIM_tile_coords(obj):
 	return udim_tile, column, row
 
 
-
 def get_UDIM_tiles(objs):
 	tiles = set()
 	for obj in objs:
@@ -259,25 +257,9 @@ def get_UDIM_tiles(objs):
 					nodes = slot.material.node_tree.nodes
 					if nodes:
 						for node in nodes:
-							if node.type == 'TEX_IMAGE' and node.image and node.image.source =='TILED':
+							if node.type == 'TEX_IMAGE' and node.image and node.image.source == 'TILED':
 								tiles.update({tile.number for tile in node.image.tiles})
 	return tiles
-
-
-
-def move_island(island, dx, dy):
-	me = bpy.context.active_object.data
-	bm = bmesh.from_edit_mesh(me)
-	uv_layer = bm.loops.layers.uv.verify()
-
-	# adjust uv coordinates
-	for face in island:
-		for loop in face.loops:
-			loop_uv = loop[uv_layer]
-			loop_uv.uv[0] += dx
-			loop_uv.uv[1] += dy
-	
-	bmesh.update_edit_mesh(me)
 
 
 def translate_island(island, uv_layer, delta):
@@ -322,7 +304,6 @@ def set_selected_faces(faces, bm, uv_layers):
 			loop[uv_layers].select = True
 
 
-
 def get_selected_uvs(bm, uv_layers):
 	"""Returns selected mesh vertices of selected UV's"""
 	uvs = set()
@@ -330,9 +311,8 @@ def get_selected_uvs(bm, uv_layers):
 		if face.select:
 			for loop in face.loops:
 				if loop[uv_layers].select:
-					uvs.add( loop[uv_layers] )
+					uvs.add(loop[uv_layers])
 	return uvs
-
 
 
 def get_selected_uv_verts(bm, uv_layers, selected=None):
@@ -343,12 +323,11 @@ def get_selected_uv_verts(bm, uv_layers, selected=None):
 			if face.select:
 				for loop in face.loops:
 					if loop[uv_layers].select:
-						verts.add( loop.vert )
+						verts.add(loop.vert)
 	else:
 		for loop in selected:
-			verts.add( loop.vert )
+			verts.add(loop.vert)
 	return verts
-
 
 
 def get_selected_uv_edges(bm, uv_layers, selected=None):
@@ -361,13 +340,23 @@ def get_selected_uv_edges(bm, uv_layers, selected=None):
 	return edges
 
 
-
-def get_selected_uv_faces(bm, uv_layers):
+def get_selected_uv_faces(bm, uv_layers, rtype=list):
 	"""Returns selected mesh faces of selected UV's"""
-	faces = [face for face in bm.faces if all([loop[uv_layers].select for loop in face.loops]) and face.select]
-	return faces
+	sync = bpy.context.scene.tool_settings.use_uv_select_sync
+	if rtype is list:
+		if sync:
+			return [f for f in bm.faces if f.select]
+		return [f for f in bm.faces if all(l[uv_layers].select for l in f.loops) and f.select]
+	if rtype is set:
+		if sync:
+			return {f for f in bm.faces if f.select}
+		return {f for f in bm.faces if all(l[uv_layers].select for l in f.loops) and f.select}
+	if rtype is iter:
+		if sync:
+			return (f for f in bm.faces if f.select)
+		return (f for f in bm.faces if all(l[uv_layers].select for l in f.loops) and f.select)
 
-
+	raise NotImplementedError(f'{rtype} is an invalid keyword argument for get_selected_uv_faces(), expect: list, set, iter')
 
 def get_vert_to_uv(bm, uv_layers):
 	vert_to_uv = {}
@@ -382,7 +371,6 @@ def get_vert_to_uv(bm, uv_layers):
 	return vert_to_uv
 
 
-
 def get_uv_to_vert(bm, uv_layers):
 	uv_to_vert = {}
 	for face in bm.faces:
@@ -390,135 +378,8 @@ def get_uv_to_vert(bm, uv_layers):
 			vert = loop.vert
 			uv = loop[uv_layers]
 			if uv not in uv_to_vert:
-				uv_to_vert[ uv ] = vert
+				uv_to_vert[uv] = vert
 	return uv_to_vert
-
-
-
-def getSelectionBBox(bm=None, uv_layers=None):
-	if bm is None:
-		bm = bmesh.from_edit_mesh(bpy.context.active_object.data)
-		uv_layers = bm.loops.layers.uv.verify()
-	sync = bpy.context.scene.tool_settings.use_uv_select_sync
-
-	bbox = {}
-
-	xmin = math.inf
-	xmax = -math.inf
-	ymin = math.inf
-	ymax = -math.inf
-
-	select = False
-	for face in bm.faces:
-		if face.select:
-			for loop in face.loops:
-				if sync or loop[uv_layers].select:
-					select = True
-					x, y = loop[uv_layers].uv
-					if xmin > x:
-						xmin = x
-					if xmax < x:
-						xmax = x
-					if ymin > y:
-						ymin = y
-					if ymax < y:
-						ymax = y
-
-	if not select:
-		return bbox
-
-	bbox['min'] = Vector((xmin, ymin))
-	bbox['max'] = Vector((xmax, ymax))
-
-	bbox['width'] = xmax - xmin
-	bbox['height'] = ymax - ymin
-
-	xcenter = (xmax + xmin)*0.5
-	ycenter = (ymax + ymin)*0.5
-
-	bbox['center'] = Vector((xcenter, ycenter))
-	bbox['area'] = bbox['width'] * bbox['height']
-	bbox['minLength'] = min(bbox['width'], bbox['height'])
-
-	return bbox
-
-
-
-def get_BBOX(group, bm, uv_layers, are_loops=False):
-	bbox = {}
-	xmin = math.inf
-	xmax = -math.inf
-	ymin = math.inf
-	ymax = -math.inf
-
-	if not are_loops:
-		for face in group:
-			for loop in face.loops:
-				x, y = loop[uv_layers].uv
-				if xmin > x:
-					xmin = x
-				if xmax < x:
-					xmax = x
-				if ymin > y:
-					ymin = y
-				if ymax < y:
-					ymax = y
-	else:
-		for loop in group:
-			x, y = loop[uv_layers].uv
-			if xmin > x:
-				xmin = x
-			if xmax < x:
-				xmax = x
-			if ymin > y:
-				ymin = y
-			if ymax < y:
-				ymax = y
-
-	bbox['min'] = Vector((xmin, ymin))
-	bbox['max'] = Vector((xmax, ymax))
-
-	bbox['width'] = xmax - xmin
-	bbox['height'] = ymax - ymin
-
-	xcenter = (xmax + xmin) * 0.5
-	ycenter = (ymax + ymin) * 0.5
-
-	bbox['center'] = Vector((xcenter, ycenter))
-	bbox['area'] = bbox['width'] * bbox['height']
-	bbox['minLength'] = min(bbox['width'], bbox['height'])
-
-	return bbox
-
-
-
-def get_BBOX_multi(all_ob_bounds):
-	multibbox = {}
-	boundsMin = Vector((math.inf, math.inf))
-	boundsMax = Vector((-math.inf, -math.inf))
-	boundsCenter = Vector((0.0,0.0))
-
-	for ob_bounds in all_ob_bounds:
-		if len(ob_bounds) > 1 :
-			boundsMin.x = min(boundsMin.x, ob_bounds['min'].x)
-			boundsMin.y = min(boundsMin.y, ob_bounds['min'].y)
-			boundsMax.x = max(boundsMax.x, ob_bounds['max'].x)
-			boundsMax.y = max(boundsMax.y, ob_bounds['max'].y)
-
-	multibbox['min'] = boundsMin
-	multibbox['max'] = boundsMax
-	multibbox['width'] = (boundsMax - boundsMin).x
-	multibbox['height'] = (boundsMax - boundsMin).y
-
-	boundsCenter.x = (boundsMax.x + boundsMin.x)/2
-	boundsCenter.y = (boundsMax.y + boundsMin.y)/2
-
-	multibbox['center'] = boundsCenter
-	multibbox['area'] = multibbox['width'] * multibbox['height']
-	multibbox['minLength'] = min(multibbox['width'], multibbox['height'])
-
-	return multibbox
-
 
 
 def get_center(group, bm, uv_layers, are_loops=False):
@@ -538,15 +399,12 @@ def get_center(group, bm, uv_layers, are_loops=False):
 	return total / n
 
 
-
 def get_selected_islands(bm, uv_layers, selected=True, extend_selection_to_islands=False):
-	islands = []
-	island = set()
-
 	sync = bpy.context.scene.tool_settings.use_uv_select_sync
 
+	islands = []
+	island = set()
 	faces = bm.faces
-	# Reset tags for unselected (if tag is False - skip)
 	if selected:
 		if sync:
 			for face in faces:
@@ -566,11 +424,10 @@ def get_selected_islands(bm, uv_layers, selected=True, extend_selection_to_islan
 				face.tag = not face.hide and face.select
 
 	for face in faces:
-		# Skip unselected and appended faces
-		if not face.tag:  # if is False:
+		if not face.tag:
 			continue
 
-		# Tag first element in island (dont add again)
+		# Tag first element in island (don`t add again)
 		face.tag = False
 
 		# Container collector of island elements
@@ -585,21 +442,18 @@ def get_selected_islands(bm, uv_layers, selected=True, extend_selection_to_islan
 				# Running through all the neighboring faces
 				for l in f.loops:
 					link_face = l.link_loop_radial_next.face
-					# Skip appended
-					if not link_face.tag:  # if is False:
+					if not link_face.tag:  # Skip appended
 						continue
 
 					for ll in link_face.loops:
-						if not ll.face.tag:  # if is False:
+						if not ll.face.tag:
 							continue
-						# If the coordinates of the vertices of adjacent
-						# faces on the uv match, then this is part of the
-						# island and we append face to the list
+						# If the coordinates of the vertices of adjacent faces on the uv match,
+						# then this is part of the island, and we append face to the list
 						if ll[uv_layers].uv != l[uv_layers].uv:
 							continue
-						# Skip non-manifold
 						if (l.link_loop_next[uv_layers].uv == ll.link_loop_prev[uv_layers].uv) or \
-								(ll.link_loop_next[uv_layers].uv == l.link_loop_prev[uv_layers].uv):
+							(ll.link_loop_next[uv_layers].uv == l.link_loop_prev[uv_layers].uv):  # Skip non-manifold
 							temp.append(ll.face)
 							ll.face.tag = False
 
@@ -644,7 +498,6 @@ def getFacesIslands(bm, uv_layers, faces, islands, disordered_island_faces):
 				break
 
 
-
 def getAllIslands(bm, uv_layers):
 	faces = {f for f in bm.faces if f.select}
 	if not faces:
@@ -656,7 +509,6 @@ def getAllIslands(bm, uv_layers):
 	getFacesIslands(bm, uv_layers, faces, islands, faces_unparsed)
 
 	return islands
-
 
 
 def getSelectionIslands(bm, uv_layers, extend_selection_to_islands=False, selected_faces=None, need_faces_selected=True, restore_selected=True):
@@ -686,7 +538,6 @@ def getSelectionIslands(bm, uv_layers, extend_selection_to_islands=False, select
 		set_selected_faces(selected_faces, bm, uv_layers)
 	
 	return islands
-
 
 
 def getSelectedUnselectedIslands(bm, uv_layers, selected_faces=None, target_faces=None, restore_selected=False):
@@ -721,7 +572,6 @@ def getSelectedUnselectedIslands(bm, uv_layers, selected_faces=None, target_face
 	return selected_islands, target_islands
 
 
-
 def getSelectionFacesIslands(bm, uv_layers, selected_faces_loops):
 	# Select islands
 	bpy.ops.uv.select_linked()
@@ -749,30 +599,6 @@ def getSelectionFacesIslands(bm, uv_layers, selected_faces_loops):
 
 	return selected_faces_islands, selected_faces_loops
 
-
-'''
-def getSelectionLoopsIslands(bm, uv_layers, selected_loops):
-	# Select islands
-	bpy.ops.uv.select_linked()
-	disordered_loops_islands = {loop for face in bm.faces for loop in face.loops if loop[uv_layers].select and loop.edge.select}
-
-	selected_loops_islands = []
-
-	for loop in selected_loops:
-		if loop in disordered_loops_islands:
-			bpy.ops.uv.select_all(action='DESELECT')
-			loop[uv_layers].select = True
-			bpy.ops.uv.select_linked()
-
-			loops_island = {l for l in disordered_loops_islands if l[uv_layers].select}
-			disordered_loops_islands.difference_update(loops_island)
-
-			selected_loops_islands.append(loops_island)
-			if not disordered_loops_islands:
-				break
-
-	return selected_loops_islands
-'''
 
 def find_min_rotate_angle(angle):
 	angle = math.degrees(angle)

--- a/utilities_uv.py
+++ b/utilities_uv.py
@@ -340,7 +340,7 @@ def get_selected_uv_edges(bm, uv_layers, selected=None):
 	return edges
 
 
-def get_selected_uv_faces(bm, uv_layers, rtype=list):
+def get_selected_uv_faces(bm, uv_layers, rtype: list | set | iter = list):
 	"""Returns selected mesh faces of selected UV's"""
 	sync = bpy.context.scene.tool_settings.use_uv_select_sync
 	if rtype is list:
@@ -514,7 +514,7 @@ def getAllIslands(bm, uv_layers):
 def getSelectionIslands(bm, uv_layers, extend_selection_to_islands=False, selected_faces=None, need_faces_selected=True, restore_selected=True):
 	if selected_faces is None:
 		if need_faces_selected:
-			selected_faces = {f for f in bm.faces if all([l[uv_layers].select for l in f.loops]) and f.select}
+			selected_faces = get_selected_uv_faces(bm, uv_layers, rtype=set)
 		else:
 			selected_faces = {f for f in bm.faces if any([l[uv_layers].select for l in f.loops]) and f.select}
 	if not selected_faces:

--- a/utilities_uv.py
+++ b/utilities_uv.py
@@ -340,7 +340,7 @@ def get_selected_uv_edges(bm, uv_layers, selected=None):
 	return edges
 
 
-def get_selected_uv_faces(bm, uv_layers, rtype: list | set | iter = list):
+def get_selected_uv_faces(bm, uv_layers, rtype: 'list | set | iter' = list):
 	"""Returns selected mesh faces of selected UV's"""
 	sync = bpy.context.scene.tool_settings.use_uv_select_sync
 	if rtype is list:

--- a/utilities_uv.py
+++ b/utilities_uv.py
@@ -287,7 +287,10 @@ def translate_island(island, uv_layer, delta):
 
 
 def rotate_island(island, uv_layer=None, angle=0, pivot=None):
-	'''Rotate a list of faces by angle (in radians) around a center'''
+	"""Rotate a list of faces by angle (in radians) around a center"""
+	if abs(angle) < 1e-05:
+		return False
+
 	rot_matrix = mathutils.Matrix.Rotation(-angle, 2)
 	if uv_layer is None:
 		me = bpy.context.active_object.data
@@ -298,13 +301,13 @@ def rotate_island(island, uv_layer=None, angle=0, pivot=None):
 			for loop in face.loops:
 				uv = loop[uv_layer]
 				uv.uv = rot_matrix @ (uv.uv - pivot) + pivot
-		return
+		return True
 
 	for face in island:
 		for loop in face.loops:
 			uv = loop[uv_layer]
 			uv.uv = uv.uv @ rot_matrix
-
+	return True
 
 def scale_island(island, uv_layer, scale_x, scale_y, pivot=None):
 	"""Scale a list of faces by 'scale_x, scale_y'. """


### PR DESCRIPTION
## This PR should be taken after 'Refactor Unwrap' as the scaling function has changed slightly.

- Add steps
- Add scale random
- Add true seed transform (now when changing properties, the random will be predictable)
- SpeedUp x1.4 in island mode
- ### SpeedDown x1.25 in face mode 
- Add clamp method for BBox
- Removed multi_obj_loop
- Removed numpy methods
- Using functions from utilities_uv (scale, rotate, translate)


The code has been greatly simplified by: f = (f,) if self.bool_face else f, this avoids a lot of conditional expressions.