### PR TITLE
Fix Smooth by UV Islands on Blender 4.1+

### DIFF
--- a/op_smoothing_uv_islands.py
+++ b/op_smoothing_uv_islands.py
@@ -75,7 +75,9 @@ def smooth_uv_islands(self, context):
 					tested_edges.add(edge)
 
 	bpy.ops.mesh.customdata_custom_splitnormals_clear()
-	bpy.context.object.data.use_auto_smooth = True
-	bpy.context.object.data.auto_smooth_angle = math.pi
+	
+	if (bpy.app.version < (4,1,0)):
+		bpy.context.object.data.use_auto_smooth = True
+		bpy.context.object.data.auto_smooth_angle = math.pi
 
 	#utilities_uv.selection_restore(bm, uv_layers)


### PR DESCRIPTION
Blender 4.1 removed the use_auto_smooth attribute (https://developer.blender.org/docs/release_notes/4.1/python_api/), so this just removes the auto smoothing if the version is greater than 4.1.

I checked it with Blender 3.6, 4.0, and 4.1, and it seems to be working in all versions.

Hope it's helpful ^^