### PR TITLE
Add Select by Color Vertex in Vertex Colors mode

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -74,7 +74,7 @@ if "bpy" in locals():
 	reload(op_stitch)
 	reload(op_unwrap_edge_peel)
 	reload(op_uv_channel_add)
-	reload(op_uv_channel_remove)	
+	reload(op_uv_channel_remove)
 	reload(op_uv_channel_swap)
 	reload(op_uv_crop)
 	reload(op_uv_fill)
@@ -744,6 +744,15 @@ class TexToolsSettings(PropertyGroup):
 		max = 1,
 		update = on_slider_meshtexture_wrap, 
 		subtype  = 'FACTOR'
+	)
+	vertex_color_threshold : FloatProperty(
+		name = "Vertex Color Threshold",
+		description = "Vertex Color threshold for color selection",
+		default = .01,
+		min = 0.0,
+		max = 0.5,
+		precision=3,
+        step=1
 	)
 
 	def get_color(hex = "808080"):
@@ -1503,6 +1512,10 @@ class UI_PT_Panel_Colors(Panel):
 								col.operator(op_color_select_vertex.op.bl_idname, text="", icon = "FACESEL").index = i
 			else:
 				col.label(text=" ")
+
+		if context.scene.texToolsSettings.color_assign_mode != "MATERIALS":
+			row = box.row(align=True)
+			row.prop(context.scene.texToolsSettings, "vertex_color_threshold", text="", expand=True)
 
 		col = box.column(align=True)
 		col.label(text="Convert:")

--- a/__init__.py
+++ b/__init__.py
@@ -747,7 +747,7 @@ class TexToolsSettings(PropertyGroup):
 	)
 	vertex_color_threshold : FloatProperty(
 		name = "Vertex Color Threshold",
-		description = "Vertex Color threshold for color selection",
+		description = "Color threshold for vertex color selection",
 		default = .01,
 		min = 0.0,
 		max = 0.5,

--- a/__init__.py
+++ b/__init__.py
@@ -752,7 +752,7 @@ class TexToolsSettings(PropertyGroup):
 		min = 0.0,
 		max = 0.5,
 		precision=3,
-        step=1
+		step=1
 	)
 
 	def get_color(hex = "808080"):

--- a/__init__.py
+++ b/__init__.py
@@ -1515,7 +1515,7 @@ class UI_PT_Panel_Colors(Panel):
 
 		if context.scene.texToolsSettings.color_assign_mode != "MATERIALS":
 			row = box.row(align=True)
-			row.prop(context.scene.texToolsSettings, "vertex_color_threshold", text="", expand=True)
+			row.prop(context.scene.texToolsSettings, "vertex_color_threshold", text="Threshold", expand=True)
 
 		col = box.column(align=True)
 		col.label(text="Convert:")

--- a/__init__.py
+++ b/__init__.py
@@ -39,6 +39,7 @@ if "bpy" in locals():
 	reload(op_color_io_export)
 	reload(op_color_io_import)
 	reload(op_color_select)
+	reload(op_color_select_vertex)
 	reload(op_island_align_edge)
 	reload(op_island_align_sort)
 	reload(op_island_align_world)
@@ -109,6 +110,7 @@ else:
 	from . import op_color_io_export
 	from . import op_color_io_import
 	from . import op_color_select
+	from . import op_color_select_vertex
 	from . import op_island_align_edge
 	from . import op_island_align_sort
 	from . import op_island_align_world
@@ -1497,6 +1499,8 @@ class UI_PT_Panel_Colors(Panel):
 						if len(bpy.context.selected_objects) == 1:
 							if bpy.context.active_object.type == 'MESH' and context.scene.texToolsSettings.color_assign_mode == 'MATERIALS':
 								col.operator(op_color_select.op.bl_idname, text="", icon = "FACESEL").index = i
+							else:
+								col.operator(op_color_select_vertex.op.bl_idname, text="", icon = "FACESEL").index = i
 			else:
 				col.label(text=" ")
 

--- a/op_color_select_vertex.py
+++ b/op_color_select_vertex.py
@@ -52,9 +52,8 @@ def select_color(self, context, index):
 	target_color[2] = pow(target_color[2],1/gamma)
 
 	# due the averaging color calculation we need to have a threshold.
-	# This is a bit of a hack but it works for now. Might need to be adjusted 
-	# depending on the colors.
-	threshold = .2
+	# Might need to be adjusted depending on the colors.
+	threshold = bpy.context.scene.texToolsSettings.vertex_color_threshold
 	
 	r = g = b = 0
 	for p in obj.data.polygons:

--- a/op_color_select_vertex.py
+++ b/op_color_select_vertex.py
@@ -42,8 +42,6 @@ def select_color(self, context, index):
 	colors = obj.data.vertex_colors.active.data
 	selected_polygons = list(filter(lambda p: p.select, obj.data.polygons))
 
-	# Target Color by hex FED861
-	# target_color = Color((0.996, 0.847, 0.380))
 	target_color = utilities_color.get_color(index).copy()
 
 	# op_color_assign attempts to fix the gamma. So we need to do the same here

--- a/op_color_select_vertex.py
+++ b/op_color_select_vertex.py
@@ -1,0 +1,83 @@
+import bpy
+import bmesh
+from mathutils import Color
+
+from . import utilities_color
+
+
+class op(bpy.types.Operator):
+	bl_idname = "uv.textools_color_select_vertex"
+	bl_label = "Select by Color Vertex"
+	bl_description = "Select faces by this color"
+	bl_options = {'UNDO'}
+	
+	index : bpy.props.IntProperty(description="Color Index", default=0)
+
+	@classmethod
+	def poll(cls, context):
+		if bpy.context.area.ui_type != 'UV':
+			return False
+		if not bpy.context.active_object:
+			return False
+		if bpy.context.active_object not in bpy.context.selected_objects:
+			return False
+		if len(bpy.context.selected_objects) != 1:
+			return False
+		if bpy.context.active_object.type != 'MESH':
+			return False
+		return True
+	
+
+	def execute(self, context):
+		select_color(self, context, self.index)
+		return {'FINISHED'}
+
+
+
+def select_color(self, context, index):
+	obj = bpy.context.active_object
+	
+	obj = bpy.context.object
+	bpy.ops.object.mode_set(mode="OBJECT")
+	colors = obj.data.vertex_colors.active.data
+	selected_polygons = list(filter(lambda p: p.select, obj.data.polygons))
+
+	# Target Color by hex FED861
+	# target_color = Color((0.996, 0.847, 0.380))
+	target_color = utilities_color.get_color(index).copy()
+
+	# op_color_assign attempts to fix the gamma. So we need to do the same here
+	# so we can match what it assigned
+	gamma = 2.2
+	target_color[0] = pow(target_color[0],1/gamma)
+	target_color[1] = pow(target_color[1],1/gamma)
+	target_color[2] = pow(target_color[2],1/gamma)
+
+	# due the averaging color calculation we need to have a threshold.
+	# This is a bit of a hack but it works for now. Might need to be adjusted 
+	# depending on the colors.
+	threshold = .2
+	
+	r = g = b = 0
+	for p in obj.data.polygons:
+		r = g = b = 0
+		for i in p.loop_indices:
+			c = colors[i].color
+			r += c[0]
+			g += c[1]
+			b += c[2]
+		r /= p.loop_total
+		g /= p.loop_total
+		b /= p.loop_total
+		source_color = Color((r, g, b))
+
+		if (abs(source_color.r - target_color.r) < threshold and
+			abs(source_color.g - target_color.g) < threshold and
+			abs(source_color.b - target_color.b) < threshold):
+
+			p.select = True
+
+	bpy.ops.object.editmode_toggle()
+
+
+bpy.utils.register_class(op)


### PR DESCRIPTION
Currently in Color ID, you can only Select by Color in Material Mode. But I wanted to be able to Select by Color Vertex in Vertex Colors mode.

This adds that functionality to Vertex Color mode.  From my basic tests it seems to work.  I tested various colors and modes and didn't notice any issues.

![image](https://github.com/franMarz/TexTools-Blender/assets/1614040/8b2cfb13-2c27-4737-a6d8-8e7cd26e6beb)