### PR TITLE
blender5 compatibility

### DIFF
--- a/op_align.py
+++ b/op_align.py
@@ -52,7 +52,7 @@ class op(bpy.types.Operator):
 				if sync:
 					corners = [luv for f in bm.faces if f.select for luv in f.loops]
 				else:
-					corners = [luv for f in bm.faces if f.select for luv in f.loops if luv[uv_layer].select]
+					corners = [luv for f in bm.faces if f.select for luv in f.loops if utilities_uv.get_loop_selection(luv, uv_layer)]
 				if not corners:
 					continue
 				if align_mode == 'SELECTION':

--- a/op_island_align_edge.py
+++ b/op_island_align_edge.py
@@ -33,14 +33,14 @@ def main(self, context):
 		bm = bmesh.from_edit_mesh(obj.data)
 		uv_layers = bm.loops.layers.uv.verify()
 
-		if not any(l[uv_layers].select_edge for f in bm.faces for l in f.loops):
+		if not any(utilities_uv.get_loop_edge_selection(l, uv_layers) for f in bm.faces for l in f.loops):
 			continue
 
 		counter += 1
 		for island in utilities_uv.get_selected_islands(bm, uv_layers, selected=False):
 			luvs = (l for f in island for l in f.loops)
 			for l in luvs:
-				if l[uv_layers].select_edge:
+				if utilities_uv.get_loop_edge_selection(l, uv_layers):
 					uv_vert0 = l[uv_layers].uv
 					uv_vert1 = l.link_loop_next[uv_layers].uv
 					diff = uv_vert1 - uv_vert0

--- a/op_island_align_world.py
+++ b/op_island_align_world.py
@@ -54,7 +54,7 @@ def main(self, context):
 	if sync:
 		selected_faces = {f for f in bm.faces if f.select}
 	else:
-		selected_faces = {f for f in bm.faces if all([loop[uv_layers].select for loop in f.loops]) and f.select}
+		selected_faces = {f for f in bm.faces if all([utilities_uv.get_loop_selection(loop, uv_layers) for loop in f.loops]) and f.select}
 	if not selected_faces:
 		return
 

--- a/op_island_straighten_edge_loops.py
+++ b/op_island_straighten_edge_loops.py
@@ -75,7 +75,7 @@ def straighten(self, bm, uv_layers, island, segment_loops):
 	for face in island:
 		face.select_set(True)
 		for loop in face.loops:
-			loop[uv_layers].select = True
+			utilities_uv.set_loop_selection(loop, uv_layers, True)
 	
 	# Make edges of the island bounds seams temporarily for a more predictable result
 	bpy.ops.uv.seams_from_islands(mark_seams=True, mark_sharp=False)

--- a/op_meshtex_create.py
+++ b/op_meshtex_create.py
@@ -156,7 +156,7 @@ def create_uv_mesh(self, context, obj, sk_create=True, bool_scale=True, delete_u
 		for faces in faces_by_island:
 			for face in faces:
 				for loop in face.loops:
-					loop[uv_layers].select = True
+					utilities_uv.set_loop_selection(loop, uv_layers, True)
 
 	if mode == 'EDIT' and not restore_selected:
 		# Workaround for selection not flushing properly from loops to EDGE Selection Mode, apparently since UV edge selection support was added to the UV space

--- a/op_relax.py
+++ b/op_relax.py
@@ -114,7 +114,7 @@ def relax(self, context):
 
 	for face_index in copied_uvs:
 		for i, loop in enumerate(bm.faces[face_index].loops):
-			if loop[uv_layers].select:
+			if utilities_uv.get_loop_selection(loop, uv_layers):
 				loop[uv_layers].uv = copied_uvs[face_index][i]
 
 	# Remove temporary mesh and restore selection mode altered by meshtex_create

--- a/op_select_islands_flipped.py
+++ b/op_select_islands_flipped.py
@@ -51,7 +51,7 @@ def select_flipped(self):
 					f.select_set(True)
 				else:
 					for l in f.loops:
-						l[uv_layer].select = True
+						utilities_uv.set_loop_selection(l, uv_layer, True)
 
 	if not counter:
 		self.report({'INFO'}, 'Flipped faces not found')

--- a/op_select_islands_identical.py
+++ b/op_select_islands_identical.py
@@ -98,7 +98,7 @@ def swap(self, context, island_stats_source):
 		for island in islands_equal:
 			for face in island:
 				for loop in face.loops:
-					loop[uv_layers].select = True
+					utilities_uv.set_loop_selection(loop, uv_layers, True)
 
 
 	if sync:

--- a/op_select_islands_outline.py
+++ b/op_select_islands_outline.py
@@ -42,7 +42,7 @@ def select_outline(self, context, bm=None, uv_layers=None): #, linkloops=True ad
 	if sync:
 		selected_loops = {l for e in bm.edges for l in e.link_loops if e.select}
 	else:
-		selected_loops = {l for f in bm.faces for l in f.loops if l[uv_layers].select_edge and l.edge.select}
+		selected_loops = {l for f in bm.faces for l in f.loops if utilities_uv.get_loop_edge_selection(l, uv_layers) and l.edge.select}
 
 	# Store previous edge seams
 	edges_seam = {l.edge for l in selected_loops if l.edge.seam}
@@ -69,8 +69,8 @@ def select_outline(self, context, bm=None, uv_layers=None): #, linkloops=True ad
 		bpy.ops.uv.select_all(action='DESELECT')
 		bpy.ops.uv.select_mode(type='EDGE')
 		for loop in boundary_loops:
-			loop[uv_layers].select = True
-			loop[uv_layers].select_edge = True
+			utilities_uv.set_loop_selection(loop, uv_layers, True)
+			utilities_uv.set_loop_edge_selection(loop, uv_layers, True)
 			# if linkloops:
 			# 	loop.link_loop_next[uv_layers].select = True
 		# Workaround for selection not flushing properly from loops to EDGE Selection Mode, apparently since UV edge selection support was added to the UV space

--- a/op_select_islands_overlap.py
+++ b/op_select_islands_overlap.py
@@ -51,7 +51,7 @@ def deselect(self, context):
 		else:
 			for face in islands[0]:
 				for loop in face.loops:
-					loop[uv_layers].select = False
+					utilities_uv.set_loop_selection(loop, uv_layers, False)
 
 		utilities_uv.multi_object_loop_stop = True
 

--- a/op_select_zero.py
+++ b/op_select_zero.py
@@ -52,7 +52,7 @@ def select_zero(self):
 						f.select_set(True)
 					else:
 						for i in f.loops:
-							i[uv_layer].select = True
+							utilities_uv.set_loop_selection(i, uv_layer, True)
 					counter += 1
 					break
 				elif len(f.loops) == 3:

--- a/op_stitch.py
+++ b/op_stitch.py
@@ -38,7 +38,7 @@ def main(self, context):
 	uv_layers = bm.loops.layers.uv.verify()
 
 	op_select_islands_outline.select_outline(self, context)
-	selection = {loop for face in bm.faces if face.select for loop in face.loops if loop[uv_layers].select_edge}
+	selection = {loop for face in bm.faces if face.select for loop in face.loops if utilities_uv.get_loop_edge_selection(loop, uv_layers)}
 
 	if not selection:
 		return
@@ -64,7 +64,7 @@ def main(self, context):
 		if remaining_islands:
 			bpy.ops.uv.select_all(action='DESELECT')
 			loop1 = next(iter(island)).loops[0]
-			loop1[uv_layers].select = True
+			utilities_uv.set_loop_selection(loop1, uv_layers, True)
 			bpy.ops.uv.select_linked()
 
 			# Selection original coordinates
@@ -72,7 +72,7 @@ def main(self, context):
 			coords_before = loop1[uv_layers].uv.copy(), loop2[uv_layers].uv.copy()
 			# Stitch
 			op_select_islands_outline.select_outline(self, context)
-			selectionBorder = {loop for face in island for loop in face.loops if loop[uv_layers].select_edge}
+			selectionBorder = {loop for face in island for loop in face.loops if utilities_uv.get_loop_edge_selection(loop, uv_layers)}
 			selectionBorder.intersection_update(extended_selection)
 
 			loopsByTarget = [[] for _ in range(len(remaining_islands))]
@@ -87,15 +87,15 @@ def main(self, context):
 			for grouped_loops in loopsByTarget:
 				bpy.ops.uv.select_all(action='DESELECT')
 				for base_loop in grouped_loops:
-					base_loop[uv_layers].select = True
-					base_loop[uv_layers].select_edge = True
+					utilities_uv.set_loop_selection(base_loop, uv_layers, True)
+					utilities_uv.set_loop_edge_selection(base_loop, uv_layers, True)
 
 				bpy.ops.uv.stitch(use_limit=False, snap_islands=True, midpoint_snap=False, clear_seams=True, mode='EDGE')
 
 			# Relocate selection
 			coords_after = loop1[uv_layers].uv, loop2[uv_layers].uv
 			if coords_before != coords_after:
-				loop1[uv_layers].select = True
+				utilities_uv.set_loop_selection(loop1, uv_layers, True)
 				bpy.ops.uv.select_linked()
 				new_island = utilities_uv.get_selected_uv_faces(bm, uv_layers)
 

--- a/op_texel_density_set.py
+++ b/op_texel_density_set.py
@@ -99,7 +99,7 @@ def set_texel_density(self, context, edit_mode, getmode, setmode, density, udim_
 			bpy.ops.uv.select_all(action='DESELECT')
 			for face in object_faces:
 				for loop in face.loops:
-					loop[uv_layers].select = True
+					utilities_uv.set_loop_selection(loop, uv_layers, True)
 
 		# Collect groups of faces to scale together
 		if setmode == 'ISLAND':

--- a/op_unwrap_edge_peel.py
+++ b/op_unwrap_edge_peel.py
@@ -103,7 +103,7 @@ def unwrap_edges_pipe(self, context, padding):
 	for face in selected_faces:
 		face.select = True
 		for loop in face.loops:
-			loop[uv_layers].select = True
+			utilities_uv.set_loop_selection(loop, uv_layers, True)
 
 	bpy.ops.uv.unwrap(method='ANGLE_BASED', margin=padding)
 
@@ -135,7 +135,7 @@ def unwrap_edges_pipe(self, context, padding):
 				for face in rectified_faces:
 					face.select_set(True)
 					for loop in face.loops:
-						loop[uv_layers].select = True
+						utilities_uv.set_loop_selection(loop, uv_layers, True)
 				bpy.ops.uv.unwrap(method='ANGLE_BASED', margin=padding)
 				op_rectify.main(me, bm, uv_layers, island, face_loops)
 
@@ -145,7 +145,7 @@ def unwrap_edges_pipe(self, context, padding):
 			bpy.ops.uv.select_all(action='DESELECT')
 			bpy.ops.uv.select_overlap(extend=False)
 			for f in rectified_faces:
-				if f.loops[0][uv_layers].select:
+				if utilities_uv.get_loop_selection(f.loops[0], uv_layers):
 					count -= 1
 				else:
 					count = 0
@@ -157,7 +157,7 @@ def unwrap_edges_pipe(self, context, padding):
 			for face in unrectified_faces:
 				face.select_set(True)
 				for loop in face.loops:
-					loop[uv_layers].select = True
+					utilities_uv.set_loop_selection(loop, uv_layers, True)
 			bpy.ops.uv.unwrap(method='ANGLE_BASED', margin=padding)
 
 
@@ -165,4 +165,4 @@ def unwrap_edges_pipe(self, context, padding):
 	for face in selected_faces:
 		face.select_set(True)
 		for loop in face.loops:
-			loop[uv_layers].select = True
+			utilities_uv.set_loop_selection(loop, uv_layers, True)

--- a/op_uv_crop.py
+++ b/op_uv_crop.py
@@ -50,7 +50,7 @@ def crop(self, distort=False, general_bbox=None):
 			if sync:
 				selection = (f for f in bm.faces if f.select)
 			else:
-				selection = (f for f in bm.faces if f.loops[0][uv_layers].select and f.select)
+				selection = (f for f in bm.faces if utilities_uv.get_loop_selection(f.loops[0], uv_layers) and f.select)
 			bbox = BBox.calc_bbox_uv(selection, uv_layers)
 			general_bbox.union(bbox)
 

--- a/op_uv_fill.py
+++ b/op_uv_fill.py
@@ -48,7 +48,7 @@ class op(bpy.types.Operator):
 			if sync:
 				selection = (f for f in bm.faces if f.select)
 			else:
-				selection = (f for f in bm.faces if f.loops[0][uv_layers].select and f.select)
+				selection = (f for f in bm.faces if utilities_uv.get_loop_selection(f.loops[0], uv_layers) and f.select)
 			points.extend(l[uv_layers].uv for f in selection for l in f.loops)
 			bmesh_ref_count_save.append(bm)
 

--- a/op_uv_unwrap.py
+++ b/op_uv_unwrap.py
@@ -42,12 +42,12 @@ def main(self, axis):
 		bm = bmesh.from_edit_mesh(obj.data)
 		uv_layer = bm.loops.layers.uv.verify()
 		# selection_store
-		sel_states = [(loop[uv_layer].select, loop[uv_layer].select_edge) for face in bm.faces for loop in face.loops]
+		sel_states = [(utilities_uv.get_loop_selection(loop, uv_layer), utilities_uv.get_loop_edge_selection(loop, uv_layer)) for face in bm.faces for loop in face.loops]
 
 		# analyze if a full uv-island has been selected.
 		full_islands = []
 		for island in utilities_uv.get_selected_islands(bm, uv_layer, selected=False, extend_selection_to_islands=True):
-			if all(loop[uv_layer].select for face in island for loop in face.loops):
+			if all(utilities_uv.get_loop_selection(loop, uv_layer) for face in island for loop in face.loops):
 				full_islands.append(list(island))
 
 		# store pins and edge seams
@@ -63,7 +63,7 @@ def main(self, axis):
 			for loop in face.loops:
 				uv = loop[uv_layer]
 				pin_state.append(uv.pin_uv)
-				uv.pin_uv = not uv.select
+				uv.pin_uv = not utilities_uv.get_loop_selection(loop, uv_layer)
 				if axis:
 					uv_coords.append(uv.uv.copy())
 


### PR DESCRIPTION
close #268

Fixed usages of the removed APIs.
bmesh.types.BMLoopUV.select
bmesh.types.BMLoopUV.select_edge

Also grepped for 
(bpy.types.MeshUVLoopLayer.)vertex_selection and edge_selection but didn't find any occurrences.