### PR TITLE
Fix for Color ID workflow, Specifically the Vertex Color portion being broken.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # TexTools for Blender #
 
+NOTES: This is a fork specifically fixing the Color ID workflow for Blender 4.5+. I have not looked at any of the other features such as UV Layouts as I do not use this tool for those purposes. I am simply sharing this in case others may want to use it.
+Signing off, 
+Wallfenstein
+
 TexTools is a free addon for Blender with a set of professional UV and Texture tools. Fully compatible with Blender 3.2 and later, most features should work for Blender versions as old as 2.8, including: UV Layout tools (Align, Rectify, Sort, Randomize...), multiple out-of-the-box Texture Baking modes, Texel Density tools, smart UV Selection operators, Color ID tools and some UV related Mesh creation utilities.
 
 Back in 2009, @renderhjs released the [Original TexTools](http://renderhjs.net/textools/) for 3DS MAX, and later, the Blender add-on, which was discontinued from the 2.79 Blender version until @SavMartin ported it to the 2.8 Blender release.

--- a/op_color_assign.py
+++ b/op_color_assign.py
@@ -1,104 +1,88 @@
 import bpy
+import bmesh
 
 from . import utilities_color
-from . import utilities_ui
-from .settings import tt_settings, prefs
 
 
 gamma = 2.2
 
 
 class op(bpy.types.Operator):
-	bl_idname = "uv.textools_color_assign"
-	bl_label = "Assign Color"
-	bl_description = "Assign color to selected Objects or faces in Edit Mode"
-	bl_options = {'UNDO'}
+    bl_idname = "uv.textools_color_assign"
+    bl_label = "Assign Color"
+    bl_description = "Assign color to selected Objects or faces in Edit Mode"
+    bl_options = {'UNDO'}
 
-	index: bpy.props.IntProperty(description="Color Index", default=0)
+    index: bpy.props.IntProperty(description="Color Index", default=0)
 
-	@classmethod
-	def poll(cls, context):
-		if bpy.context.area.ui_type != 'UV':
-			return False
-		if not bpy.context.active_object:
-			return False
-		if bpy.context.active_object not in bpy.context.selected_objects:
-			return False
-		if bpy.context.active_object.type != 'MESH':
-			return False
-		return True
+    @classmethod
+    def poll(cls, context):
+        if bpy.context.area.ui_type != 'UV':
+            return False
+        if not bpy.context.active_object:
+            return False
+        if bpy.context.active_object not in bpy.context.selected_objects:
+            return False
+        if bpy.context.active_object.type != 'MESH':
+            return False
+        return True
 
-	def execute(self, context):
-		assign_color(self, context, self.index)
-		return {'FINISHED'}
+    def execute(self, context):
+        assign_color(self, context, self.index)
+        return {'FINISHED'}
+
 
 
 def assign_color(self, context, index):
-	selected_obj = bpy.context.selected_objects.copy()
+    selected_obj = bpy.context.selected_objects.copy()
 
-	previous_mode = 'OBJECT'
-	if len(selected_obj) == 1:
-		previous_mode = bpy.context.active_object.mode
+    previous_mode = 'OBJECT'
+    if len(selected_obj) == 1:
+        previous_mode = bpy.context.active_object.mode
 
-	for obj in selected_obj:
-		# Select object
-		bpy.ops.object.mode_set(mode='OBJECT')
-		bpy.ops.object.select_all(action='DESELECT')
-		obj.select_set(True)
-		bpy.context.view_layer.objects.active = obj
+    for obj in selected_obj:
+        bpy.ops.object.mode_set(mode='OBJECT')
+        bpy.ops.object.select_all(action='DESELECT')
+        obj.select_set(state=True, view_layer=None)
+        bpy.context.view_layer.objects.active = obj
 
-		# Enter Edit mode
-		bpy.ops.object.mode_set(mode='EDIT')
+        bpy.ops.object.mode_set(mode='EDIT')
+        bm = bmesh.from_edit_mesh(obj.data)
 
-		if previous_mode == 'OBJECT':
-			bpy.ops.mesh.select_all(action='SELECT')
-		
-		if tt_settings().color_assign_mode == 'MATERIALS':
-			# Verify material slots
-			for _ in range(index+1):
-				if index >= len(obj.material_slots):
-					bpy.ops.object.material_slot_add()
+        if previous_mode == 'OBJECT':
+            bpy.ops.mesh.select_all(action='SELECT')
 
-			utilities_color.assign_slot(obj, index)
+        if bpy.context.scene.texToolsSettings.color_assign_mode == 'MATERIALS':
+            for i in range(index + 1):
+                if index >= len(obj.material_slots):
+                    bpy.ops.object.material_slot_add()
 
-			# Assign to selection
-			obj.active_material_index = index
-			bpy.ops.object.material_slot_assign()
+            utilities_color.assign_slot(obj, index)
+            obj.active_material_index = index
+            bpy.ops.object.material_slot_assign()
 
-		else:  # mode == VERTEXCOLORS
-			color = utilities_color.get_color(index).copy()
-			if prefs().bool_color_id_vertex_color_gamma:
-				# Fix Gamma
-				color[0] = pow(color[0], 1/gamma)
-				color[1] = pow(color[1], 1/gamma)
-				color[2] = pow(color[2], 1/gamma)
+        else:
+            color = list(utilities_color.get_color(index).copy())
+            color[0] = pow(color[0], 1 / gamma)
+            color[1] = pow(color[1], 1 / gamma)
+            color[2] = pow(color[2], 1 / gamma)
+            rgba = (color[0], color[1], color[2], 1.0)
 
-			# Manage Vertex Color layer
-			context_override = utilities_ui.GetContextView3D()
-			if not context_override:
-				self.report({'ERROR_INVALID_INPUT'}, "This tool requires an available View3D view.")
-				return {'CANCELLED'}
-			if 'TexTools_colorID' not in obj.data.vertex_colors:
-				obj.data.vertex_colors.new(name='TexTools_colorID')
-			obj.data.vertex_colors['TexTools_colorID'].active = True
+            utilities_color.ensure_color_layer(obj.data, utilities_color.COLOR_LAYER_NAME)
 
-			# Paint
-			bpy.ops.object.mode_set(mode='VERTEX_PAINT')
-			bpy.context.tool_settings.vertex_paint.brush.color = color
-			bpy.context.object.data.use_paint_mask = True
-			with bpy.context.temp_override(**context_override):
-				bpy.ops.paint.vertex_color_set()
-			bpy.context.object.data.use_paint_mask = False
+            # Refresh edit bmesh after creating/activating attribute so the layer is visible to bmesh.
+            bm = bmesh.from_edit_mesh(obj.data)
+            utilities_color.set_bmesh_face_colors(bm, utilities_color.COLOR_LAYER_NAME, rgba, only_selected=True)
+            bmesh.update_edit_mesh(obj.data, loop_triangles=False, destructive=False)
 
-	# restore mode
-	bpy.ops.object.mode_set(mode='OBJECT')
-	bpy.ops.object.select_all(action='DESELECT')
-	for obj in selected_obj:
-		obj.select_set(True)
-	bpy.ops.object.mode_set(mode=previous_mode)
+    bpy.ops.object.mode_set(mode='OBJECT')
+    bpy.ops.object.select_all(action='DESELECT')
+    for obj in selected_obj:
+        obj.select_set(state=True, view_layer=None)
+    bpy.ops.object.mode_set(mode=previous_mode)
 
-	# Show Material or Data Tab
-	utilities_color.update_properties_tab()
+    utilities_color.update_properties_tab()
+    utilities_color.update_view_mode()
 
-	# Change View mode
-	utilities_color.update_view_mode()
+
+bpy.utils.register_class(op)

--- a/op_color_convert_vertex_colors.py
+++ b/op_color_convert_vertex_colors.py
@@ -2,95 +2,98 @@ import bpy
 import bmesh
 
 from . import utilities_color
-from . import utilities_bake
-from . import utilities_ui
 
 
 gamma = 2.2
 
 
-
 class op(bpy.types.Operator):
-	bl_idname = "uv.textools_color_convert_to_vertex_colors"
-	bl_label = "Pack Texture"
-	bl_description = "Pack ID Colors into single texture and UVs"
-	bl_options = {'REGISTER', 'UNDO'}
-	
-	@classmethod
-	def poll(cls, context):
-		if bpy.context.area.ui_type != 'UV':
-			return False
-		if not bpy.context.active_object:
-			return False
-		if bpy.context.active_object not in bpy.context.selected_objects:
-			return False
-		if len(bpy.context.selected_objects) != 1:
-			return False
-		if bpy.context.active_object.type != 'MESH':
-			return False
-		return True
+    bl_idname = "uv.textools_color_convert_to_vertex_colors"
+    bl_label = "Pack Texture"
+    bl_description = "Pack ID Colors into single texture and UVs"
+    bl_options = {'REGISTER', 'UNDO'}
 
+    @classmethod
+    def poll(cls, context):
+        if bpy.context.area.ui_type != 'UV':
+            return False
+        if not bpy.context.active_object:
+            return False
+        if bpy.context.active_object not in bpy.context.selected_objects:
+            return False
+        if len(bpy.context.selected_objects) != 1:
+            return False
+        if bpy.context.active_object.type != 'MESH':
+            return False
+        return True
 
-	def execute(self, context):
-		convert_vertex_colors(self, context)
-		return {'FINISHED'}
+    def execute(self, context):
+        convert_vertex_colors(self, context)
+        return {'FINISHED'}
 
 
 
 def convert_vertex_colors(self, context):
-	context_override = utilities_ui.GetContextView3D()
-	if not context_override:
-		self.report({'ERROR_INVALID_INPUT'}, "This tool requires an available View3D view.")
-		return {'CANCELLED'}
+    obj = bpy.context.active_object
+    previous_mode = obj.mode
 
-	obj = bpy.context.active_object
+    # Ensure the target color attribute exists before entering edit mode.
+    bpy.ops.object.mode_set(mode='OBJECT')
+    utilities_color.ensure_color_layer(obj.data, utilities_color.COLOR_LAYER_NAME)
 
-	for i in range(len(obj.material_slots)):
-		slot = obj.material_slots[i]
-		if slot.material:
+    bpy.ops.object.mode_set(mode='EDIT')
+    bm = bmesh.from_edit_mesh(obj.data)
 
-			# Select related faces
-			bpy.ops.object.mode_set(mode='EDIT')
-			bpy.ops.mesh.select_all(action='DESELECT')
+    # Guarantee selection state is flushed before we start coloring.
+    bm.faces.ensure_lookup_table()
 
-			bm = bmesh.from_edit_mesh(bpy.context.active_object.data)
-			for face in bm.faces:
-				if face.material_index == i:
-					face.select = True
+    for i, slot in enumerate(obj.material_slots):
+        if not slot.material:
+            continue
 
-			color = utilities_color.get_color(i).copy()
-			# Fix Gamma
-			color[0] = pow(color[0],1/gamma)
-			color[1] = pow(color[1],1/gamma)
-			color[2] = pow(color[2],1/gamma)
-			
-			utilities_bake.assign_vertex_color(obj)
+        for face in bm.faces:
+            face.select = (face.material_index == i)
 
-			bpy.ops.object.mode_set(mode='VERTEX_PAINT')
-			bpy.context.tool_settings.vertex_paint.brush.color = color
-			bpy.context.object.data.use_paint_mask = True
-			with bpy.context.temp_override(**context_override):
-				bpy.ops.paint.vertex_color_set()
+        color = list(utilities_color.get_color(i).copy())
+        color[0] = pow(color[0], 1 / gamma)
+        color[1] = pow(color[1], 1 / gamma)
+        color[2] = pow(color[2], 1 / gamma)
+        rgba = (color[0], color[1], color[2], 1.0)
 
-	# Back to object mode
-	bpy.ops.object.mode_set(mode='VERTEX_PAINT')
-	bpy.context.object.data.use_paint_mask = False
+        utilities_color.set_bmesh_face_colors(
+            bm,
+            utilities_color.COLOR_LAYER_NAME,
+            rgba,
+            only_selected=True,
+        )
 
-	# Switch Properties Tab
-	for area in bpy.context.screen.areas:
-		if area.type == 'PROPERTIES':
-			for space in area.spaces:
-				if space.type == 'PROPERTIES':
-					space.context = 'DATA'
+    bmesh.update_edit_mesh(obj.data, loop_triangles=False, destructive=False)
 
-	# Switch textured shading
-	for area in bpy.context.screen.areas:
-		if area.type == 'VIEW_3D':
-			for space in area.spaces:
-				if space.type == 'VIEW_3D':
-					space.shading.type = 'SOLID'
+    bpy.ops.object.mode_set(mode='OBJECT')
 
-	# Clear materials?
-	#bpy.ops.uv.textools_color_clear()
+    for area in bpy.context.screen.areas:
+        if area.type == 'PROPERTIES':
+            for space in area.spaces:
+                if space.type == 'PROPERTIES':
+                    space.context = 'DATA'
 
-	bpy.ops.ui.textools_popup('INVOKE_DEFAULT', message="Vertex colors assigned")
+    for area in bpy.context.screen.areas:
+        if area.type == 'VIEW_3D':
+            for space in area.spaces:
+                if space.type == 'VIEW_3D':
+                    space.shading.type = 'SOLID'
+                    try:
+                        space.shading.color_type = 'ATTRIBUTE'
+                    except Exception:
+                        space.shading.color_type = 'VERTEX'
+
+    if previous_mode != 'OBJECT':
+        try:
+            bpy.ops.object.mode_set(mode=previous_mode)
+        except Exception:
+            pass
+
+    bpy.ops.ui.textools_popup('INVOKE_DEFAULT', message="Vertex colors assigned")
+
+
+bpy.utils.register_class(op)

--- a/utilities_color.py
+++ b/utilities_color.py
@@ -31,20 +31,27 @@ def safe_color(color):
 
 def assign_color(index):
     material = get_material(index)
-    if material:
-        rgb = get_color(index)
-        rgba = (rgb[0], rgb[1], rgb[2], 1)
+    if not material:
+        return
 
-        if (material.use_nodes and bpy.context.scene.render.engine == 'CYCLES') or (
-            bpy.context.scene.render.engine == 'BLENDER_EEVEE' and material.use_nodes
-        ):
-            for n in material.node_tree.nodes:
-                if n.bl_idname == "ShaderNodeBsdfPrincipled":
+    rgb = get_color(index)
+    rgba = (rgb[0], rgb[1], rgb[2], 1)
+
+    engine = bpy.context.scene.render.engine
+
+    if material.use_nodes:
+        for n in material.node_tree.nodes:
+            if n.bl_idname == "ShaderNodeBsdfPrincipled":
+                # Blender 4.x / 5.x safer lookup.
+                if "Base Color" in n.inputs:
+                    n.inputs["Base Color"].default_value = rgba
+                else:
                     n.inputs[0].default_value = rgba
-            material.diffuse_color = rgba
 
-        elif bpy.context.scene.render.engine == 'BLENDER_EEVEE' and not material.use_nodes:
-            material.diffuse_color = rgba
+        material.diffuse_color = rgba
+
+    else:
+        material.diffuse_color = rgba
 
 
 
@@ -56,18 +63,22 @@ def get_material(index):
 
         if not material:
             replace_material(index)
+            return bpy.data.materials.get(name)
 
-        if (not material.use_nodes) and bpy.context.scene.render.engine == 'CYCLES':
+        # In Blender 5.x, Eevee is usually BLENDER_EEVEE_NEXT, not BLENDER_EEVEE.
+        engine = bpy.context.scene.render.engine
+
+        if (not material.use_nodes) and engine == 'CYCLES':
             replace_material(index)
+            return bpy.data.materials.get(name)
 
-        elif bpy.context.scene.render.engine == 'BLENDER_EEVEE' and material.use_nodes:
+        elif engine in {'BLENDER_EEVEE', 'BLENDER_EEVEE_NEXT'} and material.use_nodes:
             replace_material(index)
-        else:
-            return material
+            return bpy.data.materials.get(name)
 
-    material = create_material(index)
-    assign_color(index)
-    return material
+        return material
+
+    return create_material(index)
 
 
 

--- a/utilities_color.py
+++ b/utilities_color.py
@@ -1,182 +1,285 @@
 import bpy
 import bmesh
 from mathutils import Color
-from .settings import tt_settings
+
 
 material_prefix = "TT_color_"
 gamma = 2.2
+COLOR_LAYER_NAME = "TexTools_colorID"
+
 
 
 def assign_slot(obj, index):
-	if index < len(obj.material_slots):
-		obj.material_slots[index].material = get_material(index)
-		assign_color(index)  # Verify color
+    if index < len(obj.material_slots):
+        obj.material_slots[index].material = get_material(index)
+        assign_color(index)
+
 
 
 def safe_color(color):
-	if len(color) == 3:
-		return *color, 1
-	return color
+    if len(color) == 3:
+        if bpy.app.version > (2, 80, 0):
+            return (color[0], color[1], color[2], 1)
+        return color
+    elif len(color) == 4:
+        if bpy.app.version > (2, 80, 0):
+            return color
+        return (color[0], color[1], color[2])
+    return color
+
 
 
 def assign_color(index):
-	material = get_material(index)
-	if material:
-		rgba = (*get_color(index), 1)
-		for n in material.node_tree.nodes:
-			if n.bl_idname == "ShaderNodeBsdfPrincipled":
-				n.inputs[0].default_value = rgba
-		material.diffuse_color = rgba
+    material = get_material(index)
+    if material:
+        rgb = get_color(index)
+        rgba = (rgb[0], rgb[1], rgb[2], 1)
+
+        if (material.use_nodes and bpy.context.scene.render.engine == 'CYCLES') or (
+            bpy.context.scene.render.engine == 'BLENDER_EEVEE' and material.use_nodes
+        ):
+            for n in material.node_tree.nodes:
+                if n.bl_idname == "ShaderNodeBsdfPrincipled":
+                    n.inputs[0].default_value = rgba
+            material.diffuse_color = rgba
+
+        elif bpy.context.scene.render.engine == 'BLENDER_EEVEE' and not material.use_nodes:
+            material.diffuse_color = rgba
+
 
 
 def get_material(index):
-	name = get_name(index)
-	# Material already exists?
-	if name in bpy.data.materials:
-		material = bpy.data.materials[name]
-		return material
-	material = create_material(index)
-	assign_color(index)
-	return material
+    name = get_name(index)
+
+    if name in bpy.data.materials:
+        material = bpy.data.materials[name]
+
+        if not material:
+            replace_material(index)
+
+        if (not material.use_nodes) and bpy.context.scene.render.engine == 'CYCLES':
+            replace_material(index)
+
+        elif bpy.context.scene.render.engine == 'BLENDER_EEVEE' and material.use_nodes:
+            replace_material(index)
+        else:
+            return material
+
+    material = create_material(index)
+    assign_color(index)
+    return material
+
+
+
+def replace_material(index):
+    name = get_name(index)
+    if name in bpy.data.materials:
+        material = bpy.data.materials[name]
+        slots = []
+        for obj in bpy.context.view_layer.objects:
+            for slot in obj.material_slots:
+                if slot.material == material:
+                    slots.append(slot)
+
+        bpy.data.materials.remove(material, do_unlink=True)
+
+        material = create_material(index)
+        for slot in slots:
+            slot.material = material
+
 
 
 def create_material(index):
-	name = get_name(index)
-	material = bpy.data.materials.new(name)
-	material.preview_render_type = 'FLAT'
-	material.use_nodes = True 
-	return material
+    name = get_name(index)
+    material = bpy.data.materials.new(name)
+    material.preview_render_type = 'FLAT'
+    if bpy.context.scene.render.engine == 'CYCLES':
+        material.use_nodes = True
+    return material
+
 
 
 def get_name(index):
-	return f"{material_prefix}{index:02d}"
+    return (material_prefix + "{:02d}").format(index)
+
 
 
 def get_color(index):
-	if index < tt_settings().color_ID_count:
-		return getattr(tt_settings(), f"color_ID_color_{index}")
-	return 0, 0, 0  # Default return (Black)
+    if index < bpy.context.scene.texToolsSettings.color_ID_count:
+        return getattr(bpy.context.scene.texToolsSettings, "color_ID_color_{}".format(index))
+    return (0, 0, 0)
+
 
 
 def set_color(index, color):
-	if index < tt_settings().color_ID_count:
-		setattr(tt_settings(), f"color_ID_color_{index}", color)
+    if index < bpy.context.scene.texToolsSettings.color_ID_count:
+        setattr(bpy.context.scene.texToolsSettings, "color_ID_color_{}".format(index), color)
+
+
+
+def ensure_color_layer(mesh, name=COLOR_LAYER_NAME):
+    """Create or fetch a color layer/attribute in a way that works across Blender versions."""
+    if hasattr(mesh, "color_attributes"):
+        attr = mesh.color_attributes.get(name)
+        if attr is None:
+            attr = mesh.color_attributes.new(name=name, type='BYTE_COLOR', domain='CORNER')
+        try:
+            mesh.color_attributes.active_color = attr
+        except Exception:
+            try:
+                mesh.color_attributes.active_color_index = list(mesh.color_attributes.keys()).index(name)
+            except Exception:
+                pass
+        return attr
+
+    # Legacy fallback
+    if len(mesh.vertex_colors) > 0:
+        names = [vcl.name for vcl in mesh.vertex_colors]
+        if name in names:
+            layer = mesh.vertex_colors[name]
+            layer.active = True
+        else:
+            layer = mesh.vertex_colors.new(name=name)
+            layer.active = True
+    else:
+        layer = mesh.vertex_colors.new(name=name)
+        layer.active = True
+    return layer
+
+
+
+def set_bmesh_face_colors(bm, layer_name, rgba, only_selected=True):
+    """Write color directly into bmesh loop color data instead of using paint operators."""
+    color_layer = bm.loops.layers.color.get(layer_name)
+    if color_layer is None:
+        color_layer = bm.loops.layers.float_color.get(layer_name)
+    if color_layer is None:
+        # If the edit bmesh was created before the attribute existed, make it available now.
+        raise RuntimeError(f"Color layer '{layer_name}' not found in edit mesh")
+
+    for face in bm.faces:
+        if only_selected and not face.select:
+            continue
+        for loop in face.loops:
+            loop[color_layer] = rgba
+
 
 
 def validate_face_colors(obj):
-	# Validate face colors and material slots
-	previous_mode = bpy.context.object.mode
-	count = tt_settings().color_ID_count
+    previous_mode = bpy.context.object.mode
+    count = bpy.context.scene.texToolsSettings.color_ID_count
 
-	# Verify enough material slots
-	if len(obj.material_slots) < count:
-		for i in range(count):
-			if len(obj.material_slots) < count:
-				bpy.ops.object.material_slot_add()
-				assign_slot(obj, len(obj.material_slots)-1)
-			else:
-				break
+    if len(obj.material_slots) < count:
+        for i in range(count):
+            if len(obj.material_slots) < count:
+                bpy.ops.object.material_slot_add()
+                assign_slot(obj, len(obj.material_slots) - 1)
+            else:
+                break
 
+    bpy.ops.object.mode_set(mode='EDIT')
+    bm = bmesh.from_edit_mesh(obj.data)
+    for face in bm.faces:
+        face.material_index %= count
+    obj.data.update()
 
-	# TODO: Check face.material_index
-	bpy.ops.object.mode_set(mode='EDIT')
-	bm = bmesh.from_edit_mesh(obj.data)
-	for face in bm.faces:
-		face.material_index %= count
-	obj.data.update()
+    if len(obj.material_slots) > count:
+        bpy.ops.object.mode_set(mode='OBJECT')
+        for i in range(len(obj.material_slots) - count):
+            if len(obj.material_slots) > count:
+                bpy.context.object.active_material_index = len(obj.material_slots) - 1
+                bpy.ops.object.material_slot_remove()
 
-	# Remove material slots that are not used
-	if len(obj.material_slots) > count:
-		bpy.ops.object.mode_set(mode='OBJECT')
-		for i in range(len(obj.material_slots) - count):
-			if len(obj.material_slots) > count:
-				# Remove last
-				bpy.context.object.active_material_index = len(obj.material_slots)-1
-				bpy.ops.object.material_slot_remove()
+    bpy.ops.object.mode_set(mode=previous_mode)
 
-	# Restore previous mode
-	bpy.ops.object.mode_set(mode=previous_mode)
 
 
 def hex_to_color(hex):
-	hex = hex.strip('#')
-	lv = len(hex)
-	fin = list(int(hex[i:i + lv // 3], 16) for i in range(0, lv, lv // 3))
-	r = pow(fin[0] / 255, gamma)
-	g = pow(fin[1] / 255, gamma)
-	b = pow(fin[2] / 255, gamma)
-	fin.clear()
-	fin.append(r)
-	fin.append(g)
-	fin.append(b)
-	return tuple(fin)
+    hex = hex.strip('#')
+    lv = len(hex)
+    fin = list(int(hex[i:i + lv // 3], 16) for i in range(0, lv, lv // 3))
+    r = pow(fin[0] / 255, gamma)
+    g = pow(fin[1] / 255, gamma)
+    b = pow(fin[2] / 255, gamma)
+    fin.clear()
+    fin.append(r)
+    fin.append(g)
+    fin.append(b)
+    return tuple(fin)
+
 
 
 def color_to_hex(color):
-	rgb = []
-	for i in range(3):
-		rgb.append(pow(color[i], 1.0/gamma))
+    rgb = []
+    for i in range(3):
+        rgb.append(pow(color[i], 1.0 / gamma))
 
-	r = int(rgb[0]*255)
-	g = int(rgb[1]*255)
-	b = int(rgb[2]*255)
+    r = int(rgb[0] * 255)
+    g = int(rgb[1] * 255)
+    b = int(rgb[2] * 255)
 
-	return f"#{r:02X}{g:02X}{b:02X}"
+    return "#{:02X}{:02X}{:02X}".format(r, g, b)
 
 
 
 def get_color_id(index, count, jitter=False):
-	# Get unique color
-	color = Color()
-	indexList = [0, 171, 64, 213, 32, 96, 160, 224, 16, 48, 80, 112, 144, 176, 208, 240, 8, 24, 40, 56, 72, 88, 104,
-		120, 136, 152, 168, 184, 200, 216, 232, 248, 4, 12, 20, 28, 36, 44, 52, 60, 68, 76, 84, 92, 100, 108, 116, 124,
-		132, 140, 148, 156, 164, 172, 180, 188, 196, 204, 212, 220, 228, 236, 244, 252, 2, 6, 10, 14, 18, 22, 26, 30, 34,
-		38, 42, 46, 50, 54, 58, 62, 66, 70, 74, 78, 82, 86, 90, 94, 98, 102, 106, 110, 114, 118, 122, 126, 130, 134, 138,
-		142, 146, 150, 154, 158, 162, 166, 170, 174, 178, 182, 186, 190, 194, 198, 202, 206, 210, 214, 218, 222, 226, 230,
-		234, 238, 242, 246, 250, 254, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31, 33, 35, 37, 39, 41, 43,
-		45, 47, 49, 51, 53, 55, 57, 59, 61, 63, 65, 67, 69, 71, 73, 75, 77, 79, 81, 83, 85, 87, 89, 91, 93, 95, 97, 99, 101,
-		103, 105, 107, 109, 111, 113, 115, 117, 119, 121, 123, 125, 127, 129, 131, 133, 135, 137, 139, 141, 143, 145, 147,
-		149, 151, 153, 155, 157, 159, 161, 163, 165, 167, 169, 128, 173, 175, 177, 179, 181, 183, 185, 187, 189, 191, 193,
-		195, 197, 199, 201, 203, 205, 207, 209, 211, 192, 215, 217, 219, 221, 223, 225, 227, 229, 231, 233, 235, 237, 239,
-		241, 243, 245, 247, 249, 251, 253, 255]
+    color = Color()
+    indexList = [0, 171, 64, 213, 32, 96, 160, 224, 16, 48, 80, 112, 144, 176, 208, 240, 8, 24, 40, 56, 72, 88, 104,
+        120, 136, 152, 168, 184, 200, 216, 232, 248, 4, 12, 20, 28, 36, 44, 52, 60, 68, 76, 84, 92, 100, 108, 116, 124,
+        132, 140, 148, 156, 164, 172, 180, 188, 196, 204, 212, 220, 228, 236, 244, 252, 2, 6, 10, 14, 18, 22, 26, 30, 34,
+        38, 42, 46, 50, 54, 58, 62, 66, 70, 74, 78, 82, 86, 90, 94, 98, 102, 106, 110, 114, 118, 122, 126, 130, 134, 138,
+        142, 146, 150, 154, 158, 162, 166, 170, 174, 178, 182, 186, 190, 194, 198, 202, 206, 210, 214, 218, 222, 226, 230,
+        234, 238, 242, 246, 250, 254, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31, 33, 35, 37, 39, 41, 43,
+        45, 47, 49, 51, 53, 55, 57, 59, 61, 63, 65, 67, 69, 71, 73, 75, 77, 79, 81, 83, 85, 87, 89, 91, 93, 95, 97, 99, 101,
+        103, 105, 107, 109, 111, 113, 115, 117, 119, 121, 123, 125, 127, 129, 131, 133, 135, 137, 139, 141, 143, 145, 147,
+        149, 151, 153, 155, 157, 159, 161, 163, 165, 167, 169, 128, 173, 175, 177, 179, 181, 183, 185, 187, 189, 191, 193,
+        195, 197, 199, 201, 203, 205, 207, 209, 211, 192, 215, 217, 219, 221, 223, 225, 227, 229, 231, 233, 235, 237, 239,
+        241, 243, 245, 247, 249, 251, 253, 255]
 
-	i = 0
-	if index > 255:
-		while index > 255:
-			index -= 256
-			i += 1
-	
-	if jitter:
-		color.hsv = ( ( indexList[index] + 1/(2**i) ) / 256 ), 0.9, 1.0
-	else:
-		color.hsv = ( index / (count) ), 0.9, 1.0
-	
-	return color
+    i = 0
+    if index > 255:
+        while index > 255:
+            index -= 256
+            i += 1
+
+    if jitter:
+        color.hsv = ((indexList[index] + 1 / (2 ** i)) / 256), 0.9, 1.0
+    else:
+        color.hsv = (index / (count)), 0.9, 1.0
+
+    return color
+
 
 
 def update_properties_tab():
-	for area in bpy.context.screen.areas:
-		if area.type == 'PROPERTIES':
-			for space in area.spaces:
-				if space.type == 'PROPERTIES':
-					if tt_settings().color_assign_mode == 'MATERIALS':
-						space.context = 'MATERIAL'
-					else:	#mode == VERTEXCOLORS
-						space.context = 'DATA'
+    for area in bpy.context.screen.areas:
+        if area.type == 'PROPERTIES':
+            for space in area.spaces:
+                if space.type == 'PROPERTIES':
+                    if bpy.context.scene.texToolsSettings.color_assign_mode == 'MATERIALS':
+                        space.context = 'MATERIAL'
+                    else:
+                        space.context = 'DATA'
+
 
 
 def update_view_mode():
-	for area in bpy.context.screen.areas:
-		if area.type == 'VIEW_3D':
-			for space in area.spaces:
-				if space.type == 'VIEW_3D':
-					if space.shading.type == 'RENDERED':
-						continue
-					elif space.shading.type == 'MATERIAL' and tt_settings().color_assign_mode == 'MATERIALS':
-						continue
-					space.shading.type = 'SOLID'
-					if tt_settings().color_assign_mode == 'MATERIALS':
-						if space.shading.color_type != 'TEXTURE':
-							space.shading.color_type = 'MATERIAL'
-					else:	#mode == VERTEXCOLORS
-						space.shading.color_type = 'VERTEX'
+    for area in bpy.context.screen.areas:
+        if area.type == 'VIEW_3D':
+            for space in area.spaces:
+                if space.type == 'VIEW_3D':
+                    if space.shading.type == 'RENDERED':
+                        continue
+                    elif space.shading.type == 'MATERIAL' and bpy.context.scene.texToolsSettings.color_assign_mode == 'MATERIALS':
+                        continue
+
+                    space.shading.type = 'SOLID'
+                    if bpy.context.scene.texToolsSettings.color_assign_mode == 'MATERIALS':
+                        if space.shading.color_type != 'MATERIAL':
+                            space.shading.color_type = 'MATERIAL'
+                    else:
+                        try:
+                            space.shading.color_type = 'ATTRIBUTE'
+                        except Exception:
+                            # Older Blender versions.
+                            space.shading.color_type = 'VERTEX'


### PR DESCRIPTION
I've only modified the scripts for op_color_assign, op_color_convert_vertex_color, and utilities_color.
The main issue I was able to note was that the script was using outdated ways of variables and functions like vertex_colors and vertex_color_set(). So they have been replaced with direct mesh color attribute writes.

While I've found this to work, it is worth noting I have mostly just generated this code and I haven't touched anything else in this version and in turn any issues that may be present with UV unwrapping tools. If you want to go through and try and make this code better / more reliable, please let me know as this was just a quick fix to get it working again for me personally
I have also only tested this for a short while and on Blender 4.5. Though I hope that these fixes continue to work moving forward.
Additional note, changes made to stop recursion issue with utilities_color in Blender 5.1.